### PR TITLE
fix: pyobjc-framework-AppKit does not exist on PyPI — use pyobjc-framework-Cocoa

### DIFF
--- a/install.md
+++ b/install.md
@@ -7,7 +7,7 @@ Use once. For phone work, read `SKILL.md`.
 - macOS Sequoia+ with iPhone Mirroring paired to the phone (open the app once
   manually to pair — pairing prompts need the physical phone).
 - Python 3.12+ with pyobjc (`pip install pyobjc-framework-Quartz
-  pyobjc-framework-Vision pyobjc-framework-AppKit`).
+  pyobjc-framework-Vision pyobjc-framework-Cocoa`).
 - The terminal app needs two permissions in System Settings > Privacy &
   Security. **The toggles require the user:**
   - **Accessibility** — taps and keystrokes. Takes effect immediately.
@@ -36,7 +36,7 @@ open "x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenCapt
 ```bash
 git clone https://github.com/ShawnPana/phone-harness ~/.phone-harness   # canonical home
 cd ~/.phone-harness
-pip install pyobjc-framework-Quartz pyobjc-framework-Vision pyobjc-framework-AppKit
+pip install pyobjc-framework-Quartz pyobjc-framework-Vision pyobjc-framework-Cocoa
 pip install -e . --no-deps            # installs the global `phone-harness` command
 
 # register as an agent skill so Claude Code / Codex auto-use it (see below)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ requires-python = ">=3.10"
 dependencies = [
     "pyobjc-framework-Quartz",
     "pyobjc-framework-Vision",
-    "pyobjc-framework-AppKit",
+    "pyobjc-framework-Cocoa",
     "pyobjc-framework-ApplicationServices",
 ]
 


### PR DESCRIPTION
The `AppKit` module imported by `mirror.py` and `admin.py` ships in **`pyobjc-framework-Cocoa`**. There is no `pyobjc-framework-AppKit` package on PyPI — `https://pypi.org/simple/pyobjc-framework-appkit/` returns 404.

As a result both documented install paths fail on a clean machine:

```
$ pip install -e .
ERROR: No matching distribution found for pyobjc-framework-AppKit

$ uv tool install --editable .
  × No solution found when resolving dependencies:
  ╰─▶ Because pyobjc-framework-appkit was not found in the package registry
      and phone-harness==0.1.0 depends on pyobjc-framework-appkit, we can
      conclude that phone-harness==0.1.0 cannot be used.
```

This swaps the dependency in `pyproject.toml` and the two `pip install` lines in `install.md`. No source changes are needed — `from AppKit import NSRunningApplication, NSWorkspace` keeps working, since Cocoa provides the module.

Verified on macOS 26.4 / Python 3.14 (pyobjc 12.2.1): install now succeeds and `--doctor` walks the ladder through Accessibility, Screen Recording, and the app checks.