### PR TITLE
fix: window discovery + interstitial detection break on non-English macOS

### DIFF
--- a/src/phone_harness/helpers.py
+++ b/src/phone_harness/helpers.py
@@ -25,7 +25,10 @@ AGENT_WORKSPACE = Path(
 # these is a PHYSICAL action only the user can do (open the app, and if it says
 # "iPhone in Use", LOCK the phone). The agent must never tap through them.
 _BLOCKED_MARKERS = ("iphone in use", "lock your iphone", "mirroring ended",
-                    "to connect")
+                    "to connect",
+                    # zh-Hans localizations of the same interstitials
+                    "iphone 使用中", "iphone使用中", "锁定你的 iphone",
+                    "锁定你的iphone", "镜像已结束", "若要连接")
 
 
 def connection_state():

--- a/src/phone_harness/mirror.py
+++ b/src/phone_harness/mirror.py
@@ -22,11 +22,20 @@ TMP.mkdir(exist_ok=True)
 # --- window / app state ---
 
 def find_window():
-    """{x, y, w, h, id} of the mirroring window in screen points, or None."""
+    """{x, y, w, h, id} of the mirroring window in screen points, or None.
+
+    Windows are matched by the owner PID of the com.apple.ScreenContinuity
+    process, not by kCGWindowOwnerName — the owner name is localized (e.g.
+    "iPhone镜像" on a Chinese system), so name matching breaks off-English.
+    """
+    app = running_app()
+    if app is None:
+        return None
+    pid = app.processIdentifier()
     wins = Quartz.CGWindowListCopyWindowInfo(
         Quartz.kCGWindowListOptionOnScreenOnly, Quartz.kCGNullWindowID) or []
     for w in wins:
-        if w.get("kCGWindowOwnerName") == APP_NAME and w.get("kCGWindowLayer", 1) == 0:
+        if w.get("kCGWindowOwnerPID") == pid and w.get("kCGWindowLayer", 1) == 0:
             b = w["kCGWindowBounds"]
             if b["Width"] < 100:  # ignore panels/toolbars
                 continue


### PR DESCRIPTION
On a non-English macOS the mirroring window is never found, so `connection_state()` returns `no-window` and `--doctor` fails at *mirroring window found* **even when the phone is connected and its screen is visible**.

### Cause
`find_window()` matches on `kCGWindowOwnerName == "iPhone Mirroring"`, but that owner name is **localized**. On a zh-Hans system the window reports:

```
kCGWindowOwnerName = "iPhone镜像"
```

so the exact-string match never hits. Same class of bug in `helpers._BLOCKED_MARKERS`, which only lists English strings for the connect / "iPhone in Use" / "mirroring ended" interstitials, so `connection_state()` can never return `blocked` on a localized system.

### Fix
- `find_window()`: match by the **owner PID** of the `com.apple.ScreenContinuity` process (already resolved via `running_app()`) instead of the localized owner name. The bundle id is locale-stable.
- `_BLOCKED_MARKERS`: add the zh-Hans equivalents of the interstitial strings.

No API changes. Verified on **macOS 26.4 (zh-Hans) / Python 3.14 / pyobjc 12.2.1**: before the patch `--doctor` stopped at *mirroring window found*; after it walks through capture + OCR, and taps/scrolls land correctly.

Note: the marker list covers zh-Hans; other locales will still need their strings added, but the PID-based window match already fixes discovery for *every* locale.