### PR TITLE
fix: correct pyobjc dependency and Vision OCR options for pyobjc 12.x

### DIFF
--- a/install.md
+++ b/install.md
@@ -7,7 +7,7 @@ Use once. For phone work, read `SKILL.md`.
 - macOS Sequoia+ with iPhone Mirroring paired to the phone (open the app once
   manually to pair — pairing prompts need the physical phone).
 - Python 3.12+ with pyobjc (`pip install pyobjc-framework-Quartz
-  pyobjc-framework-Vision pyobjc-framework-AppKit`).
+  pyobjc-framework-Vision pyobjc-framework-Cocoa`).
 - The terminal app needs two permissions in System Settings > Privacy &
   Security. **The toggles require the user:**
   - **Accessibility** — taps and keystrokes. Takes effect immediately.
@@ -36,7 +36,7 @@ open "x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenCapt
 ```bash
 git clone https://github.com/ShawnPana/phone-harness ~/.phone-harness   # canonical home
 cd ~/.phone-harness
-pip install pyobjc-framework-Quartz pyobjc-framework-Vision pyobjc-framework-AppKit
+pip install pyobjc-framework-Quartz pyobjc-framework-Vision pyobjc-framework-Cocoa
 pip install -e . --no-deps            # installs the global `phone-harness` command
 
 # register as an agent skill so Claude Code / Codex auto-use it (see below)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ requires-python = ">=3.10"
 dependencies = [
     "pyobjc-framework-Quartz",
     "pyobjc-framework-Vision",
-    "pyobjc-framework-AppKit",
+    "pyobjc-framework-Cocoa",
     "pyobjc-framework-ApplicationServices",
 ]
 

--- a/src/phone_harness/ocr.py
+++ b/src/phone_harness/ocr.py
@@ -24,7 +24,7 @@ def recognize(path, window):
     bottom-left origin; screen points have a top-left origin, hence the flip.
     """
     handler = Vision.VNImageRequestHandler.alloc().initWithURL_options_(
-        NSURL.fileURLWithPath_(path), {})
+        NSURL.fileURLWithPath_(path), None)
     request = Vision.VNRecognizeTextRequest.alloc().init()
     request.setRecognitionLevel_(Vision.VNRequestTextRecognitionLevelAccurate)
     ok, err = handler.performRequests_error_([request], None)


### PR DESCRIPTION
Two independent bugs that together stop a fresh install from working. Both reproduced on macOS 27.0 with Python 3.13 and pyobjc 12.2.1.

## 1. `pyobjc-framework-AppKit` does not exist on PyPI

`pyproject.toml` and `install.md` both list `pyobjc-framework-AppKit`. That distribution isn't on PyPI — `https://pypi.org/simple/pyobjc-framework-appkit/` returns **404**, while `pyobjc-framework-cocoa` returns 200. Any resolver-backed install fails before it starts:

```
× No solution found when resolving dependencies:
  ╰─▶ Because pyobjc-framework-appkit was not found in the package registry
      and phone-harness==0.1.0 depends on pyobjc-framework-appkit, we can
      conclude that phone-harness==0.1.0 cannot be used.
```

The `AppKit` module ships inside **`pyobjc-framework-Cocoa`**:

```python
>>> import importlib.metadata as md
>>> [d.metadata["Name"] for d in md.distributions()
...  if any(str(f).startswith("AppKit/") for f in (d.files or []))]
['pyobjc-framework-Cocoa']
```

The Fast Path in `install.md` uses `pip install -e . --no-deps`, which skips dependency resolution entirely — probably why this hasn't surfaced before. Anyone installing without `--no-deps`, or using a resolver like uv, hits it immediately.

## 2. Vision OCR raises on pyobjc 12.x

`recognize()` passes an empty dict as the options argument:

```python
handler = Vision.VNImageRequestHandler.alloc().initWithURL_options_(
    NSURL.fileURLWithPath_(path), {})
```

On pyobjc 12.2.1 that raises:

```
ValueError: NSInvalidArgumentException - key does not exist
```

`None` is accepted. Minimal reproduction:

```python
import Vision
from Foundation import NSURL
url = NSURL.fileURLWithPath_("/path/to/any.png")

Vision.VNImageRequestHandler.alloc().initWithURL_options_(url, {})    # raises
Vision.VNImageRequestHandler.alloc().initWithURL_options_(url, None)  # OK
```

This isn't confined to `ocr()`. `connection_state()` and the doctor's own OCR check both route through `recognize()`, so on a current pyobjc **every** read path fails — including `--doctor`, which dies at the first screen read with a traceback rather than a diagnosable message. From a user's point of view the tool appears completely broken right after a by-the-book install.

## Notes

Each fix is one line plus the matching doc references. Happy to split this into two PRs if you'd rather review them separately, and equally happy to adjust if you'd prefer to pin a pyobjc range instead of changing the call.
