### PR TITLE
docs: venv install path, ./phone-harness gotcha, and pull-to-refresh note

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -100,3 +100,9 @@ raises a clear message (call `connection_state()` yourself to check —
   fine for in-app buttons and list rows.
 - Mouse taps map to touches 1:1, but there is no multi-touch: no pinch, no
   two-finger gestures.
+- **Pull-to-refresh needs a wheel overscroll, not a drag.** A synthetic
+  touch-drag does not register as a pull: the list stays pinned, nothing
+  refreshes, and the screen then settles looking exactly as it would have on
+  success — so the failure is silent and you will read stale content as fresh.
+  Scroll the wheel past the top instead. Verify by capturing *during* the
+  gesture: if the content hasn't moved, the pull never happened.

--- a/install.md
+++ b/install.md
@@ -63,6 +63,23 @@ to that location, so keep the folder at `~/.phone-harness` (or re-run `pip
 install -e .` if you relocate it). If your Python can't reach PyPI to resolve the
 pyobjc deps, `--no-deps` skips them (they're installed by the line above).
 
+## Externally managed Python
+
+If `pip install` exits with `error: externally-managed-environment` (PEP 668 —
+common with Homebrew and system Python), install into a venv and put the entry
+point on your PATH yourself:
+
+```bash
+cd ~/.phone-harness
+python3 -m venv .venv                 # or: uv venv .venv
+.venv/bin/pip install pyobjc-framework-Quartz pyobjc-framework-Vision \
+    pyobjc-framework-Cocoa pyobjc-framework-ApplicationServices
+.venv/bin/pip install -e . --no-deps
+ln -s ~/.phone-harness/.venv/bin/phone-harness ~/.local/bin/phone-harness
+```
+
+`.venv/` is already in `.gitignore`, so this leaves the tree clean.
+
 ## Register as a skill
 
 So the agent reaches for phone-harness on its own, register `SKILL.md` as a
@@ -91,3 +108,7 @@ Common cases:
   Mirroring shows a connect screen — open the app manually once.
 - **Taps do nothing**: Accessibility missing, or another window stole focus —
   events land only when the mirroring window is frontmost.
+- **`--doctor` says pyobjc is missing even though you installed it**: you ran
+  `./phone-harness --doctor`. The `./` form is the dev launcher and always uses
+  the system `python3`, which won't see packages installed anywhere else. Run
+  the installed `phone-harness --doctor` instead.


### PR DESCRIPTION
Three small documentation additions, each from a real stumble during a first-time install and first session of phone work. No code changes.

## 1. `install.md` — externally managed Python (PEP 668)

`pip install ...` fails outright on Homebrew and system Python:

```
error: externally-managed-environment
```

Since `install.md` is the "use once" document, a reader hits this on the very first command with no guidance. Added a short section showing the venv route, including the symlink that keeps `phone-harness` on PATH — which matters here, because the whole design depends on the command being callable from any directory.

Uses `.venv/`, which is already in `.gitignore`, so the tree stays clean.

## 2. `install.md` — `./phone-harness --doctor` vs `phone-harness --doctor`

The `./phone-harness` dev launcher hardcodes the system `python3`:

```sh
PYTHONPATH="$DIR/src" exec python3 -m phone_harness.run "$@"
```

If pyobjc lives anywhere other than that interpreter (a venv, pipx, uv), `./phone-harness --doctor` reports pyobjc missing on an otherwise perfect install. The "If It Fails" section says to run `--doctor` without distinguishing the two forms, and the failure looks exactly like the thing the doctor is meant to diagnose — so it sends people to reinstall dependencies they already have. Added a troubleshooting entry.

## 3. `SKILL.md` — pull-to-refresh needs a wheel overscroll

A synthetic touch-drag does not register as a pull-to-refresh. The list stays pinned, nothing refreshes, and the screen then settles looking exactly as it would have on success.

This one is worth calling out specifically because it **fails silently and produces confidently wrong answers**. In my case the app's list had been refreshed a moment earlier and showed nothing pending; a drag-based "refresh" appeared to work, and the stale view was very nearly reported as the true state. A wheel overscroll refreshed properly and revealed the pending items.

`SKILL.md` already recommends wheel over drag for *scrolling lists*, but the failure mode for refresh is different in kind — a scroll that doesn't move is visible, whereas a refresh that doesn't fire is not. Added a gotcha entry noting that capturing *during* the gesture is what distinguishes them.
