### PR TITLE
Fix window discovery on non-English macOS, and the AppKit dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ requires-python = ">=3.10"
 dependencies = [
     "pyobjc-framework-Quartz",
     "pyobjc-framework-Vision",
-    "pyobjc-framework-AppKit",
+    "pyobjc-framework-Cocoa",
     "pyobjc-framework-ApplicationServices",
 ]
 

--- a/src/phone_harness/mirror.py
+++ b/src/phone_harness/mirror.py
@@ -25,8 +25,14 @@ def find_window():
     """{x, y, w, h, id} of the mirroring window in screen points, or None."""
     wins = Quartz.CGWindowListCopyWindowInfo(
         Quartz.kCGWindowListOptionOnScreenOnly, Quartz.kCGNullWindowID) or []
+    # Match on pid, not owner name: the app's display name is localized
+    # ("iPhone鏡像輸出" on a zh-Hant system) but the bundle id never is.
+    app = running_app()
+    pid = app.processIdentifier() if app else None
     for w in wins:
-        if w.get("kCGWindowOwnerName") == APP_NAME and w.get("kCGWindowLayer", 1) == 0:
+        owner_matches = (w.get("kCGWindowOwnerPID") == pid if pid is not None
+                         else w.get("kCGWindowOwnerName") == APP_NAME)
+        if owner_matches and w.get("kCGWindowLayer", 1) == 0:
             b = w["kCGWindowBounds"]
             if b["Width"] < 100:  # ignore panels/toolbars
                 continue


### PR DESCRIPTION
Two independent install/setup fixes, one commit each. Found while setting the
project up on a Traditional Chinese macOS 26.5 system with Homebrew Python 3.14.

### 1. `find_window()` never matches on a localized system

`find_window()` compared `kCGWindowOwnerName` against the literal string
`"iPhone Mirroring"`. That display name is localized, so on any non-English
system the window is never found — on zh-Hant the app reports `iPhone鏡像輸出`.

The symptom is `--doctor` failing at `mirroring window found` with the phone
connected, paired, and both permissions granted, which points the user at a
pairing problem that isn't there. The window was on screen the whole time:

```
'iPhone鏡像輸出' | bounds= {X=904; Y=58; Width=318; Height=701} | layer=0
```

Now matches on the owning pid, resolved from the bundle id via `running_app()`.
Bundle ids aren't localized. Falls back to the old name comparison when the app
isn't running, preserving the existing `None` result for that case.

After the change all eight doctor checks pass, including capture (691KB) and
OCR (34 text boxes).

### 2. `pyobjc-framework-AppKit` isn't a real package

There's no such distribution on PyPI — `AppKit` ships inside
`pyobjc-framework-Cocoa`. A plain `pip install .` dies with:

```
ERROR: Could not find a version that satisfies the requirement pyobjc-framework-AppKit
       (from versions: none)
```

`install.md` sidesteps this by pinning deps by hand and then running
`pip install -e . --no-deps`, which is likely why it hasn't come up, but the
metadata is wrong for anyone installing normally. `pip install --dry-run .`
resolves cleanly with the fix.

### Separately: `_BLOCKED_MARKERS` — not fixed here, but worth flagging

Two problems with the markers in `helpers.py`, both left alone since neither
has a fix I could verify:

**Too loose.** `"to connect"` is a substring of several unrelated strings in
`ScreenContinuityUI`:

```
Turn on Mac Bluetooth to connect.
Turn on Mac Wi-Fi to connect.
Some iCloud data isn't syncing. Follow the instructions in System Settings on this Mac to connect.
```

That last one is an ordinary notification, not a mirroring interstitial. If it
lands on screen, `connection_state()` returns `blocked` and the harness refuses
to work. This affects English systems too.

**English-only.** The markers are English, so on a localized system
`connection_state()` returns `ready` on a connect / "iPhone in Use" screen and
`ensure_mirroring()` waves it through — the harness then taps blind at
coordinates on a screen it has misread, which is exactly what the skill's
"never tap through the connect screen" rule exists to prevent. Unlike the
`find_window()` bug this one fails open and silently.

I didn't attempt a fix because I'd be guessing the localized strings, and the
app bundle can't supply them: every `*.lproj` directory ships empty on disk and
only the English base strings are in the framework binary. Guessing wrong is
worse than the current state — it would look fixed. Getting the real strings
means capturing that screen live in each locale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
