### PR TITLE
Fix window lookup on non-English macOS, and doctor reporting success while failing

### DIFF
--- a/src/phone_harness/admin.py
+++ b/src/phone_harness/admin.py
@@ -1,47 +1,60 @@
 """Diagnostics: `phone-harness --doctor` walks the permission/session ladder."""
-import os, subprocess, sys, tempfile
+import os, subprocess, tempfile
 from pathlib import Path
 
 
-def _check(label, ok, hint=""):
+_failures = []
+
+
+def _check(label, ok, hint="", fatal=True):
+    """Print a check result and, unless it is explicitly non-fatal, remember a
+    failure. The verdict is computed from `_failures`, not from the call sites
+    remembering to fold each result into a running flag."""
     mark = "PASS" if ok else "FAIL"
     print(f"  [{mark}] {label}" + (f" — {hint}" if not ok and hint else ""))
+    if not ok and fatal:
+        _failures.append(label)
     return ok
 
 
 def run_doctor():
     print("phone-harness doctor\n")
-    ok = True
+    _failures.clear()
 
     try:
         import Quartz, Vision, AppKit  # noqa: F401
-        ok &= _check("pyobjc frameworks (Quartz, Vision, AppKit)", True)
+        _check("pyobjc frameworks (Quartz, Vision, AppKit)", True)
     except ImportError as e:
         _check("pyobjc frameworks", False,
                f"pip install pyobjc-framework-Quartz pyobjc-framework-Vision ({e})")
         return 1
 
     from ApplicationServices import AXIsProcessTrusted
-    ok &= _check(
+    _check(
         "Accessibility permission (taps & keystrokes)", AXIsProcessTrusted(),
         "System Settings > Privacy & Security > Accessibility: enable your terminal")
 
     import Quartz as Q
-    ok &= _check(
+    _check(
         "Screen Recording permission (seeing the phone)",
         bool(Q.CGPreflightScreenCaptureAccess()),
         "System Settings > Privacy & Security > Screen Recording: enable your terminal")
 
     from . import mirror
-    ok &= _check(f"{mirror.APP_NAME} installed", Path(mirror.APP_PATH).exists(),
+    _check(f"{mirror.APP_NAME} installed", Path(mirror.APP_PATH).exists(),
                  "requires macOS Sequoia+ with a paired iPhone")
 
     running = mirror.running_app() is not None
     _check(f"{mirror.APP_NAME} running", running,
-           "will auto-launch on first use — not fatal")
+           "will auto-launch on first use — not fatal", fatal=False)
 
     win = mirror.find_window()
+    # Running with no window is the common case when the phone is locked or the
+    # session was never started, so the hint has to tell those two apart.
     _check("mirroring window found", win is not None,
+           "iPhone Mirroring is running but has no window — click it and "
+           "connect your phone (it may be waiting on the lock screen)"
+           if running else
            "open iPhone Mirroring once manually to pair the phone")
 
     if win:
@@ -52,7 +65,7 @@ def run_doctor():
                 ["screencapture", "-x", "-o", "-l", str(win["id"]), path],
                 check=True)
             size = os.path.getsize(path)
-            ok &= _check(f"window capture works ({size} bytes)", size > 20_000,
+            _check(f"window capture works ({size} bytes)", size > 20_000,
                          "capture is blank — Screen Recording permission "
                          "needs a terminal restart to take effect")
             if size > 20_000:
@@ -62,9 +75,15 @@ def run_doctor():
         finally:
             os.unlink(path)
 
-    print("\nall clear" if ok else "\nfix the FAILs above, then re-run")
+    if win is None:
+        print("\n  [SKIP] window capture and Vision OCR — no window to test "
+              "against;\n         these are the checks that prove the harness "
+              "can actually see the phone")
+
+    print("\nall clear" if not _failures
+          else "\nfix the FAILs above, then re-run")
     print("\nnote: these are the permissions currently known to be required. A "
           "fresh\nmachine may still prompt for more the first time an action "
           "runs — approve\nthem in System Settings if a step silently does "
           "nothing despite this passing.")
-    return 0 if ok else 1
+    return 0 if not _failures else 1

--- a/src/phone_harness/mirror.py
+++ b/src/phone_harness/mirror.py
@@ -25,8 +25,14 @@ def find_window():
     """{x, y, w, h, id} of the mirroring window in screen points, or None."""
     wins = Quartz.CGWindowListCopyWindowInfo(
         Quartz.kCGWindowListOptionOnScreenOnly, Quartz.kCGNullWindowID) or []
+    # The owner name is localized ("Espelhamento do iPhone" on pt-BR), so match
+    # the running process by bundle id and fall back to the English name.
+    app = running_app()
+    pid = app.processIdentifier() if app else None
     for w in wins:
-        if w.get("kCGWindowOwnerName") == APP_NAME and w.get("kCGWindowLayer", 1) == 0:
+        owned = (w.get("kCGWindowOwnerPID") == pid if pid is not None
+                 else w.get("kCGWindowOwnerName") == APP_NAME)
+        if owned and w.get("kCGWindowLayer", 1) == 0:
             b = w["kCGWindowBounds"]
             if b["Width"] < 100:  # ignore panels/toolbars
                 continue


### PR DESCRIPTION
Two independent bugs found while setting the harness up on a pt-BR Mac. Both are reproducible and neither changes any public API.

## 1. `find_window()` never matches on a non-English system

`kCGWindowOwnerName` is localized. On pt-BR the mirroring window is owned by **"Espelhamento do iPhone"**, so comparing it against the literal `"iPhone Mirroring"` matched nothing and every lookup reported no phone window — on a machine where mirroring was running and visible.

Fixed by resolving the running process through the bundle id (`com.apple.ScreenContinuity`) and comparing owner pids, falling back to the English name when the app is not running. This should fix the harness on every non-English macOS, not just Portuguese.

## 2. `doctor` prints "all clear" and exits 0 while a check is failing

The `mirroring window found` check never folded its result into the verdict flag:

```python
win = mirror.find_window()
_check("mirroring window found", win is not None, "...")   # result discarded
```

So a run could print `[FAIL] mirroring window found` and then `all clear`, exiting 0. Worse, the two checks that prove the harness can actually see the phone — window capture and Vision OCR — live inside `if win:`, so that same run verified nothing at all and still reported success. Observed output before the fix:

```
  [PASS] iPhone Mirroring running
  [FAIL] mirroring window found — open iPhone Mirroring once manually to pair the phone

all clear
```

Rather than adding one more `ok &=` at that call site, `_check` now records its own failures, so no call site can drop one by forgetting. The one deliberately non-fatal check (the app not running, since it auto-launches) states that with `fatal=False` instead of by silently discarding its result, and skipped checks print a `[SKIP]` line so an incomplete run can't read as a clean one.

## Verification

On a pt-BR Mac (macOS 25.5, 3440x1440, iPhone connected):

- Before: window lookup returned `None` despite a visible mirroring window; doctor exited **0** with a `[FAIL]` on screen.
- After: 8/8 checks pass, exit **0**, capture 275,829 bytes and Vision OCR returning 25 text boxes.
- Failure path re-checked by disconnecting the phone: doctor exits **1**, prints the `[SKIP]` line for capture/OCR, and the hint distinguishes "running but no window" from "never opened".

Happy to split these into two PRs if you'd prefer.

I also have a third fix on hand for tap staleness — `tap_text` computes coordinates a capture + OCR (~0.4s) before the click, plus `_focus()`'s 0.5s sleep, so on a moving screen the tap lands on whatever occupies those pixels by then. It re-confirms position before committing and raises rather than tapping blind. Left out here because it adds parameters and a new failure mode, which felt like your call rather than a plain bug fix. Say the word and I'll open it separately.