### PR TITLE
Install fixes: nonexistent AppKit dependency, PEP 668 route, launcher interpreter trap, and a pull-to-refresh gotcha

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -98,5 +98,15 @@ raises a clear message (call `connection_state()` yourself to check —
   label and nothing happens; the icon is ~35 points above it. Use
   `tap_icon("Weather")` (agent helper) on the Home Screen; `tap_text` works
   fine for in-app buttons and list rows.
+- **Pull-to-refresh needs a wheel overscroll, not a drag.** A synthetic
+  touch-drag does not trip the gesture: the list stays pinned, nothing
+  refreshes, and the screen then settles looking exactly as it would have on
+  success. This fails differently from a scroll that does not move — a stalled
+  scroll is visible in the next capture, whereas a refresh that never fired
+  leaves stale content that reads as current, so an out-of-date list can be
+  reported as the true state. Overscroll past the top with the wheel
+  (`scroll_screen("down")`, or `mirror.scroll_wheel` at the list center) and
+  capture *during* the gesture — seeing the spinner is what tells the two
+  apart, since by the time the screen settles both outcomes look the same.
 - Mouse taps map to touches 1:1, but there is no multi-touch: no pinch, no
   two-finger gestures.

--- a/install.md
+++ b/install.md
@@ -63,6 +63,34 @@ to that location, so keep the folder at `~/.phone-harness` (or re-run `pip
 install -e .` if you relocate it). If your Python can't reach PyPI to resolve the
 pyobjc deps, `--no-deps` skips them (they're installed by the line above).
 
+## If pip refuses: externally managed Python
+
+Homebrew and system Python mark themselves externally managed (PEP 668), so the
+`pip install` lines above stop before installing anything:
+
+```text
+error: externally-managed-environment
+```
+
+Install into a virtualenv instead. The symlink is not optional — the whole
+design depends on `phone-harness` being callable from any directory, because
+that is how the skill invokes it:
+
+```bash
+cd ~/.phone-harness
+python3 -m venv .venv
+.venv/bin/pip install pyobjc-framework-Quartz pyobjc-framework-Vision pyobjc-framework-AppKit
+.venv/bin/pip install -e . --no-deps
+
+mkdir -p ~/bin
+ln -sf ~/.phone-harness/.venv/bin/phone-harness ~/bin/phone-harness
+```
+
+`.venv/` is already in `.gitignore`, so the tree stays clean. Confirm `~/bin` is
+on your PATH (`echo $PATH | tr ':' '\n' | grep -x "$HOME/bin"`) and add it in
+your shell profile if it is not — otherwise the command resolves only from this
+directory and the skill cannot reach it.
+
 ## Register as a skill
 
 So the agent reaches for phone-harness on its own, register `SKILL.md` as a
@@ -91,3 +119,17 @@ Common cases:
   Mirroring shows a connect screen — open the app manually once.
 - **Taps do nothing**: Accessibility missing, or another window stole focus —
   events land only when the mirroring window is frontmost.
+- **`--doctor` reports pyobjc missing on an install that works**: check which
+  form you ran. `./phone-harness` is the dev launcher and it hardcodes the
+  system interpreter:
+
+  ```sh
+  PYTHONPATH="$DIR/src" exec python3 -m phone_harness.run "$@"
+  ```
+
+  If pyobjc lives anywhere else — a venv, pipx, uv — that interpreter genuinely
+  cannot import it, and the failure looks identical to the missing dependency
+  the doctor exists to catch, so it sends you to reinstall packages you already
+  have. Run the installed command `phone-harness --doctor`, or point the
+  launcher at the right interpreter yourself:
+  `PYTHONPATH=src .venv/bin/python3 -m phone_harness.run --doctor`.

--- a/install.md
+++ b/install.md
@@ -7,7 +7,7 @@ Use once. For phone work, read `SKILL.md`.
 - macOS Sequoia+ with iPhone Mirroring paired to the phone (open the app once
   manually to pair — pairing prompts need the physical phone).
 - Python 3.12+ with pyobjc (`pip install pyobjc-framework-Quartz
-  pyobjc-framework-Vision pyobjc-framework-AppKit`).
+  pyobjc-framework-Vision pyobjc-framework-Cocoa`).
 - The terminal app needs two permissions in System Settings > Privacy &
   Security. **The toggles require the user:**
   - **Accessibility** — taps and keystrokes. Takes effect immediately.
@@ -36,7 +36,7 @@ open "x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenCapt
 ```bash
 git clone https://github.com/ShawnPana/phone-harness ~/.phone-harness   # canonical home
 cd ~/.phone-harness
-pip install pyobjc-framework-Quartz pyobjc-framework-Vision pyobjc-framework-AppKit
+pip install pyobjc-framework-Quartz pyobjc-framework-Vision pyobjc-framework-Cocoa
 pip install -e . --no-deps            # installs the global `phone-harness` command
 
 # register as an agent skill so Claude Code / Codex auto-use it (see below)
@@ -79,7 +79,7 @@ that is how the skill invokes it:
 ```bash
 cd ~/.phone-harness
 python3 -m venv .venv
-.venv/bin/pip install pyobjc-framework-Quartz pyobjc-framework-Vision pyobjc-framework-AppKit
+.venv/bin/pip install pyobjc-framework-Quartz pyobjc-framework-Vision pyobjc-framework-Cocoa
 .venv/bin/pip install -e . --no-deps
 
 mkdir -p ~/bin

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ requires-python = ">=3.10"
 dependencies = [
     "pyobjc-framework-Quartz",
     "pyobjc-framework-Vision",
-    "pyobjc-framework-AppKit",
+    "pyobjc-framework-Cocoa",
     "pyobjc-framework-ApplicationServices",
 ]
 


### PR DESCRIPTION
Three documentation additions, each from a real stumble during a first-time install and a first session of phone work. No code changes.

## 1. `install.md` — externally managed Python (PEP 668)

The Fast Path's `pip install` fails outright on Homebrew and system Python:

```text
error: externally-managed-environment
```

`install.md` is the use-once document, so a reader hits this on the very first command with nothing in front of them. Added a section showing the venv route, including the symlink that keeps `phone-harness` on PATH — which matters here specifically, because the design depends on the command being callable from any directory.

Uses `.venv/`, already in `.gitignore`, so the tree stays clean.

## 2. `install.md` — `./phone-harness --doctor` vs `phone-harness --doctor`

The dev launcher hardcodes the system interpreter:

```sh
PYTHONPATH="$DIR/src" exec python3 -m phone_harness.run "$@"
```

If pyobjc lives anywhere else — a venv, pipx, uv — `./phone-harness --doctor` reports pyobjc missing on an otherwise perfect install. Reproduced on a working machine:

```
$ ./phone-harness --doctor
  [FAIL] pyobjc frameworks — pip install pyobjc-framework-Quartz pyobjc-framework-Vision (No module named 'Quartz')

$ phone-harness --doctor
  [PASS] pyobjc frameworks (Quartz, Vision, AppKit)

$ PYTHONPATH=src .venv/bin/python3 -m phone_harness.run --doctor
  [PASS] pyobjc frameworks (Quartz, Vision, AppKit)
```

The "If It Fails" section said to run `--doctor` without distinguishing the two forms, and the failure looks exactly like the thing the doctor is meant to diagnose — so it sends people to reinstall dependencies they already have. Added a troubleshooting entry with both working invocations.

Documented rather than patched, since changing the launcher to prefer a local `.venv` is a design call rather than a doc fix. Glad to send that separately if you'd rather fix it at the source.

## 3. `SKILL.md` — pull-to-refresh needs a wheel overscroll

A synthetic touch-drag does not register as a pull-to-refresh. The list stays pinned, nothing refreshes, and the screen then settles looking exactly as it would have on success.

Worth calling out specifically because it fails silently and produces confidently wrong answers. In my case the app's list had been refreshed a moment earlier and showed nothing pending; a drag-based "refresh" appeared to work, and the stale view was very nearly reported as the true state. A wheel overscroll refreshed properly and revealed the pending items.

`SKILL.md` already recommends wheel over drag for scrolling lists, but the failure mode for refresh is different in kind — a scroll that doesn't move is visible, whereas a refresh that doesn't fire is not. The added entry notes that capturing *during* the gesture is what distinguishes them.

---

Separate from #10, which carries the two code fixes (localized window lookup, doctor verdict).