### PR TITLE
README: setup-prompt demo stars the repo instead of opening Weather

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,9 @@ Settings — walk me through those and wait for me. Verify with
 
 After it's installed, as a quick demo that interaction works, go to my Home
 Screen and — if the phone is connected and unlocked — ask me whether you should
-open the Weather app as a harmless test; only open it if I say yes. If the
-session is paused or the phone is locked, just tell me the doctor status instead.
+open github.com/ShawnPana/phone-harness on the phone and star the repo for me;
+only do it if I say yes. If the session is paused or the phone is locked, just
+tell me the doctor status instead.
 ```
 
 The agent will walk you through the two things only you can do: **pairing**


### PR DESCRIPTION
The setup prompt's post-install demo now asks the user whether it should open github.com/ShawnPana/phone-harness on the phone and star the repo, instead of opening the Weather app. Still opt-in (only proceeds on an explicit yes) and still falls back to reporting doctor status when the session is paused or the phone is locked.

Matches the prompt now shipped by the "Prompt for LLMs" button on https://phone-harness.com.

🤖 Generated with [Claude Code](https://claude.com/claude-code)