### PR TITLE
background: drive the phone without focus by default

### DIFF
--- a/src/phone_harness/helpers.py
+++ b/src/phone_harness/helpers.py
@@ -11,12 +11,23 @@ from pathlib import Path
 from . import ocr as _ocr
 
 # Every helper below rests on two primitives — capture + tap — so the transport
-# is swappable. PHONE_HARNESS_BACKGROUND=1 selects the background backend, which
-# drives iPhone Mirroring without ever taking focus (SkyLight event records);
-# the default is the classic mirror backend that must be frontmost.
-_BACKGROUND = os.environ.get("PHONE_HARNESS_BACKGROUND") in ("1", "true", "yes")
-mirror = importlib.import_module(
-    ".background" if _BACKGROUND else ".mirror", __package__)
+# is swappable. The background backend drives iPhone Mirroring without ever
+# taking focus (SkyLight event records) and is the default: not stealing the
+# user's screen is what you want unless something is broken. Set
+# PHONE_HARNESS_BACKGROUND=0 to force the classic mirror backend, which must
+# bring the window frontmost. If the background backend can't load (its private
+# SkyLight symbols aren't guaranteed across macOS builds), fall back rather than
+# leaving the harness unusable.
+_BACKGROUND = os.environ.get("PHONE_HARNESS_BACKGROUND", "1").lower() not in (
+    "0", "false", "no")
+if _BACKGROUND:
+    try:
+        mirror = importlib.import_module(".background", __package__)
+    except Exception:
+        mirror = importlib.import_module(".mirror", __package__)
+        _BACKGROUND = False
+else:
+    mirror = importlib.import_module(".mirror", __package__)
 
 tap = mirror.tap
 long_press = mirror.long_press


### PR DESCRIPTION
`PHONE_HARNESS_BACKGROUND=1` was opt-in, and the variable appears only in `background.py`'s module docstring — not in SKILL.md, the README, or the skill instructions an agent actually reads. So the backgrounding work shipped effectively switched off: anything following the skill kept taking over the screen.

This flips the default. `PHONE_HARNESS_BACKGROUND=0` still forces the classic mirror backend, and a failed import of the background backend falls back to mirror rather than leaving the harness unusable (the SkyLight symbols aren't guaranteed across macOS builds).

Verified on this machine with the phone connected:
- no env var → `phone_harness.background`, and `screen_info()["frontmost"]` reads False while Finder stays the active app
- `PHONE_HARNESS_BACKGROUND=0` → `phone_harness.mirror`
- OCR and connection-state detection both work unfocused

🤖 Generated with [Claude Code](https://claude.com/claude-code)