### PR TITLE
focus: read frontmost from the window list, not stale NSWorkspace

### DIFF
--- a/src/phone_harness/background.py
+++ b/src/phone_harness/background.py
@@ -38,7 +38,6 @@ import ctypes, ctypes.util, struct, tempfile, time
 from pathlib import Path
 
 import Quartz
-from AppKit import NSRunningApplication, NSWorkspace
 
 from . import mirror
 
@@ -73,9 +72,11 @@ find_window = mirror.find_window
 running_app = mirror.running_app
 
 
-def is_frontmost():
-    front = NSWorkspace.sharedWorkspace().frontmostApplication()
-    return bool(front and front.bundleIdentifier() == BUNDLE_ID)
+# Shared with the mirror backend: NSWorkspace.frontmostApplication() is stale
+# in a process with no run loop, so it is never used for this. Nothing here
+# needs focus, but screen_info() reports the value and a wrong answer sends
+# people hunting for focus bugs that are not there.
+is_frontmost = mirror.is_frontmost
 
 
 def activate():

--- a/src/phone_harness/mirror.py
+++ b/src/phone_harness/mirror.py
@@ -9,7 +9,7 @@ import subprocess, tempfile, time
 from pathlib import Path
 
 import Quartz
-from AppKit import NSRunningApplication, NSWorkspace
+from AppKit import NSRunningApplication
 
 APP_NAME = "iPhone Mirroring"
 BUNDLE_ID = "com.apple.ScreenContinuity"
@@ -40,21 +40,61 @@ def running_app():
     return apps[0] if apps else None
 
 
+def frontmost_window():
+    """The frontmost normal-layer window, or None.
+
+    NOT NSWorkspace.frontmostApplication(): that value is delivered by a
+    workspace notification, and this process has no run loop to receive one,
+    so it returns whatever was true when the process first looked and never
+    updates. Believing it is how input ends up in the wrong app — activate()
+    would see a stale "already frontmost" and skip focusing entirely, and
+    every CGEvent after that lands in whatever the user actually has focused.
+    The window list is queried live, costs ~7ms, and needs no run loop.
+    """
+    wins = Quartz.CGWindowListCopyWindowInfo(
+        Quartz.kCGWindowListOptionOnScreenOnly
+        | Quartz.kCGWindowListExcludeDesktopElements,
+        Quartz.kCGNullWindowID) or []
+    for w in wins:                      # front-to-back order
+        if w.get("kCGWindowLayer", 1) == 0:
+            return w
+    return None
+
+
 def is_frontmost():
-    front = NSWorkspace.sharedWorkspace().frontmostApplication()
-    return bool(front and front.bundleIdentifier() == BUNDLE_ID)
+    app = running_app()
+    if app is None:
+        return False
+    win = frontmost_window()
+    return bool(win) and win.get("kCGWindowOwnerPID") == app.processIdentifier()
 
 
-def activate():
-    """Bring iPhone Mirroring frontmost. Does NOT launch it — opening the app
-    and connecting the phone is the user's job, not the agent's."""
+def activate(timeout=2.5):
+    """Bring iPhone Mirroring frontmost and *confirm* it. Does NOT launch it —
+    opening the app and connecting the phone is the user's job, not the agent's.
+
+    Raises rather than returning unfocused: a silent failure here means every
+    subsequent tap and drag is delivered to some other app, which is both
+    confusing to debug and potentially destructive.
+    """
     app = running_app()
     if app is None:
         raise RuntimeError(
             f"{APP_NAME} isn't running — open it and connect your phone.")
-    if not is_frontmost():
-        app.activateWithOptions_(1 << 1)  # NSApplicationActivateIgnoringOtherApps
-        time.sleep(0.5)
+    if is_frontmost():
+        return
+    app.activateWithOptions_(1 << 1)  # NSApplicationActivateIgnoringOtherApps
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        time.sleep(0.05)
+        if is_frontmost():
+            return
+    win = frontmost_window() or {}
+    owner = win.get("kCGWindowOwnerName", "unknown")
+    raise RuntimeError(
+        f"could not bring {APP_NAME} frontmost after {timeout:.1f}s — "
+        f"{owner!r} still has focus. Input would be swallowed, so nothing "
+        f"was sent.")
 
 
 def ensure_window(timeout=5.0):


### PR DESCRIPTION
## The bug

`is_frontmost()` used `NSWorkspace.frontmostApplication()`. That value is delivered by a workspace **notification**, and the harness runs in a plain Python process with no run loop to receive one — so it is frozen at whatever was true the first time the process looked, and never updates.

Measured, in one process, after calling `activateWithOptions_`:

| | NSWorkspace | System Events |
|---|---|---|
| start | `com.mitchellh.ghostty` | `com.mitchellh.ghostty` |
| after activate | `com.mitchellh.ghostty` | `com.apple.ScreenContinuity` |
| t+2.4s | `com.mitchellh.ghostty` | `com.apple.ScreenContinuity` |

It never converges.

## Why it matters

The damage is in `activate()`:

```python
if not is_frontmost():
    app.activateWithOptions_(1 << 1)
    time.sleep(0.5)
```

Once the stale read says "already frontmost", this returns **without activating**. Every `CGEvent` after that is delivered to whichever app the user actually has focused — silently. That is the precise failure `mirror.py`'s docstring warns about ("the window must be frontmost or events are swallowed"), produced by the code meant to prevent it.

In practice: run some taps, then click into your terminal, then run more taps. The first batch works, the second lands in the terminal, and nothing reports an error.

It also makes `screen_info()["frontmost"]` wrong, which sends you hunting for focus bugs that are not there.

## The fix

Read the frontmost normal-layer window from `CGWindowListCopyWindowInfo` (front-to-back, first `kCGWindowLayer == 0`) and compare its owner PID. Live, no run loop, and **~7ms** versus ~178ms for an `osascript` round trip.

`activate()` now polls to confirm it actually took focus, and on failure raises naming the app that still holds it, instead of proceeding to send input nowhere:

```
could not bring iPhone Mirroring frontmost after 2.5s — 'Ghostty' still has
focus. Input would be swallowed, so nothing was sent.
```

`background.py` shares the same implementation. It never needs focus, but it does report the value, so it should not carry a second stale copy. The now-unused `NSWorkspace` imports are dropped.

## Verification

Regression across all three states, including the one the old code got wrong:

```
ghostty focused   -> is_frontmost(): False   (want False)
mirroring focused -> is_frontmost(): True    (want True)
back to ghostty   -> is_frontmost(): False   (want False; old code said True)
```

Also confirmed the background backend still loads and drives the phone (`scroll_wheel` flick 8.7% frame change, `drag` 7.2%).

## Scope

Detection and confirmation only — no change to how events are synthesized, and no behaviour change for the background backend's input path, which does not depend on focus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)