### PR TITLE
iOS reliability: window discovery, focus tracking, and dead-session detection

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -62,8 +62,7 @@ PY
 
 This is the user's real phone. Stop and ask before anything outward-facing or
 hard to reverse: sending a message, posting, purchasing, deleting, changing
-settings. Navigating and reading for the user's own task is fine, but don't
-linger in personal content (Messages, Photos, Mail) beyond what the task needs.
+settings.
 
 ## Connection is the user's job
 

--- a/install.md
+++ b/install.md
@@ -7,7 +7,7 @@ Use once. For phone work, read `SKILL.md`.
 - macOS Sequoia+ with iPhone Mirroring paired to the phone (open the app once
   manually to pair — pairing prompts need the physical phone).
 - Python 3.12+ with pyobjc (`pip install pyobjc-framework-Quartz
-  pyobjc-framework-Vision pyobjc-framework-AppKit`).
+  pyobjc-framework-Vision pyobjc-framework-Cocoa`).
 - The terminal app needs two permissions in System Settings > Privacy &
   Security. **The toggles require the user:**
   - **Accessibility** — taps and keystrokes. Takes effect immediately.
@@ -36,7 +36,7 @@ open "x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenCapt
 ```bash
 git clone https://github.com/ShawnPana/phone-harness ~/.phone-harness   # canonical home
 cd ~/.phone-harness
-pip install pyobjc-framework-Quartz pyobjc-framework-Vision pyobjc-framework-AppKit
+pip install pyobjc-framework-Quartz pyobjc-framework-Vision pyobjc-framework-Cocoa
 pip install -e . --no-deps            # installs the global `phone-harness` command
 
 # register as an agent skill so Claude Code / Codex auto-use it (see below)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ requires-python = ">=3.10"
 dependencies = [
     "pyobjc-framework-Quartz",
     "pyobjc-framework-Vision",
-    "pyobjc-framework-AppKit",
+    "pyobjc-framework-Cocoa",
     "pyobjc-framework-ApplicationServices",
 ]
 

--- a/src/phone_harness/background.py
+++ b/src/phone_harness/background.py
@@ -34,7 +34,7 @@ Keyboard (type_text/press) still briefly activates the window: the keyboard
 event-record layout isn't implemented yet, so those fall back to the mirror
 path. Mouse actions are fully background.
 """
-import ctypes, ctypes.util, struct, tempfile, time
+import ctypes, ctypes.util, os, struct, subprocess, tempfile, time
 from pathlib import Path
 
 import Quartz
@@ -69,7 +69,21 @@ _LMOUSE_DOWN, _LMOUSE_UP, _LMOUSE_DRAGGED = 1, 2, 6
 
 # --- window / app state (reused from mirror; none of these activate) ---
 
-find_window = mirror.find_window
+def find_window():
+    """The phone window, on the active Space or not.
+
+    SkyLight event records are addressed to a process and a window id, so this
+    backend reaches the window wherever it is. mirror.py keeps the on-screen
+    default because it posts CGEvents at global screen coordinates, which land
+    on whatever is actually in front.
+
+    Inheriting mirror's default is why a terminal on a different Space from the
+    phone made the harness report a disconnected phone (#8) — the window was
+    there the whole time, just not on the Space being asked about.
+    """
+    return mirror.find_window(on_screen=False)
+
+
 running_app = mirror.running_app
 window_ax_content = mirror.window_ax_content
 
@@ -119,10 +133,27 @@ def capture(path=None, retries=2):
             if Quartz.CGImageDestinationFinalize(dest):
                 return path, win
             last = "could not encode PNG"
+        elif _screencapture(win, path):
+            # CGWindowListCreateImage renders nothing for a window that is not
+            # on the active Space. `screencapture -l` still reaches it, with
+            # live frames rather than a stale backing store. It costs a
+            # subprocess, so it stays the fallback. Its image is Retina where
+            # the fast path is point-resolution; ocr.recognize derives the
+            # scale from the window, so both work.
+            return path, win
         else:
-            last = "CGWindowListCreateImage returned nothing"
+            last = "CGWindowListCreateImage returned nothing, screencapture failed"
         time.sleep(0.3)
     raise RuntimeError(f"background capture failed: {last}")
+
+
+def _screencapture(win, path):
+    """Window capture via the screencapture binary. True if it wrote a PNG."""
+    if os.path.exists(path):
+        os.remove(path)
+    subprocess.run(["screencapture", "-x", "-o", "-l", str(win["id"]), path],
+                   capture_output=True)
+    return os.path.exists(path) and os.path.getsize(path) > 1000
 
 
 # --- input (hands), no focus ---

--- a/src/phone_harness/background.py
+++ b/src/phone_harness/background.py
@@ -38,7 +38,7 @@ import ctypes, ctypes.util, struct, tempfile, time
 from pathlib import Path
 
 import Quartz
-from AppKit import NSRunningApplication, NSWorkspace
+from AppKit import NSRunningApplication
 
 from . import mirror
 
@@ -73,9 +73,10 @@ find_window = mirror.find_window
 running_app = mirror.running_app
 
 
-def is_frontmost():
-    front = NSWorkspace.sharedWorkspace().frontmostApplication()
-    return bool(front and front.bundleIdentifier() == BUNDLE_ID)
+# Shared with the mirror backend. Nothing here needs focus, but screen_info()
+# reports the value and a wrong answer sends people hunting for focus bugs
+# that are not there.
+is_frontmost = mirror.is_frontmost
 
 
 def activate():

--- a/src/phone_harness/background.py
+++ b/src/phone_harness/background.py
@@ -71,6 +71,7 @@ _LMOUSE_DOWN, _LMOUSE_UP, _LMOUSE_DRAGGED = 1, 2, 6
 
 find_window = mirror.find_window
 running_app = mirror.running_app
+window_ax_content = mirror.window_ax_content
 
 
 # Shared with the mirror backend. Nothing here needs focus, but screen_info()

--- a/src/phone_harness/helpers.py
+++ b/src/phone_harness/helpers.py
@@ -48,19 +48,39 @@ AGENT_WORKSPACE = Path(
 # Distinctive text on the not-connected interstitials. Reconnecting past any of
 # these is a PHYSICAL action only the user can do (open the app, and if it says
 # "iPhone in Use", LOCK the phone). The agent must never tap through them.
+# Fallback only. The primary check is structural (see connection_state), and
+# a phrase list cannot be complete: it missed "Connection Paused" and the Mac
+# login screen in English, and misses every interstitial on a non-English
+# system.
 _BLOCKED_MARKERS = ("iphone in use", "lock your iphone", "mirroring ended",
-                    "to connect")
+                    "to connect", "connection paused", "connection interrupted",
+                    "is locked", "enter the mac login", "try again")
 
 
 def connection_state():
     """'ready' | 'blocked' | 'no-window' | 'not-running'.
 
-    'blocked' means a connect / 'iPhone in Use' / paused interstitial is on
-    screen. Cheap to call; use it to decide whether to proceed."""
+    'blocked' means an interstitial is up — iPhone in Use, paused, ended,
+    connect, or the Mac login screen — and nothing should be tapped or typed
+    until the user clears it.
+
+    Detected structurally: the live phone image is a video stream that
+    accessibility cannot see into, so a working session exposes no UI inside
+    the window, while every interstitial is an ordinary Mac view with labels
+    and a button. That holds in any language and for screens Apple has not
+    shipped yet, where matching known phrases does neither — the old list
+    missed both "Connection Paused" and the Mac login prompt, and reported
+    'ready' for a password field.
+
+    The phrase list is kept as a fallback in case an interstitial exposes no
+    accessibility content.
+    """
     if mirror.running_app() is None:
         return "not-running"
     if mirror.find_window() is None:
         return "no-window"
+    if mirror.window_ax_content():
+        return "blocked"
     path, win = mirror.capture()  # window exists, so this won't launch anything
     texts = " ".join(o["text"] for o in _ocr.recognize(path, win)).lower()
     return "blocked" if any(m in texts for m in _BLOCKED_MARKERS) else "ready"
@@ -87,11 +107,18 @@ def ensure_mirroring():
         raise RuntimeError(
             "iPhone Mirroring is open but no phone is connected. Please connect "
             "your phone in the app, then retry.")
+    # Quote the interstitial itself rather than guessing which one it is.
+    # Button titles are unreliable — the same screen reported 'Connect' once
+    # and an empty title a minute later — so only static text is used.
+    said = " ".join(t for role, t in mirror.window_ax_content()
+                    if role == "AXStaticText" and t)
+    detail = f" It says: {said}" if said else ""
     raise RuntimeError(
-        "iPhone Mirroring is not connected — it's showing a connect / 'iPhone "
-        "in Use' screen. This needs you: open iPhone Mirroring and connect the "
-        "phone, and if it says 'iPhone in Use', LOCK your iPhone so mirroring "
-        "can resume. Then retry. I will not tap Connect for you.")
+        "iPhone Mirroring is not connected — an interstitial is on screen."
+        + detail
+        + " This needs you: clear it on the Mac, and if it says 'iPhone in "
+        "Use', LOCK your iPhone so mirroring can resume. Then retry. I will "
+        "not tap Connect for you.")
 
 
 def screen_info():

--- a/src/phone_harness/mirror.py
+++ b/src/phone_harness/mirror.py
@@ -41,8 +41,17 @@ def find_window():
     for w in wins:
         if w.get("kCGWindowOwnerPID") == pid and w.get("kCGWindowLayer", 1) == 0:
             b = w["kCGWindowBounds"]
-            if b["Width"] < 100:  # ignore panels/toolbars
-                continue
+            # No size filter. The old `Width < 100` guard was there to skip
+            # panels and toolbars, but PID + on-screen + layer 0 already
+            # excludes those: the app's other windows (Settings, Welcome, and
+            # four unnamed 1512x33 strips) are never in the on-screen list, so
+            # this loop sees exactly one candidate. What the guard did hit was
+            # a real mirroring window that macOS had shrunk — with Stage
+            # Manager on, an inactive window is parked in the left rail at
+            # about 38x130, which is on-screen and genuinely the phone. The
+            # guard discarded it, so every time another app took the stage the
+            # harness reported a disconnected phone (#8). Window list order is
+            # front to back, so the first match is the frontmost.
             return {"x": b["X"], "y": b["Y"], "w": b["Width"], "h": b["Height"],
                     "id": int(w["kCGWindowNumber"])}
     return None

--- a/src/phone_harness/mirror.py
+++ b/src/phone_harness/mirror.py
@@ -23,8 +23,14 @@ TMP.mkdir(exist_ok=True)
 
 # --- window / app state ---
 
-def find_window():
+def find_window(on_screen=True):
     """{x, y, w, h, id} of the mirroring window in screen points, or None.
+
+    on_screen=False also finds the window when it is on another Space, hidden,
+    or minimized. Only backends that address the window by id can use that:
+    SkyLight event records reach it wherever it is, while CGEvents are posted
+    at global screen coordinates and would land on whatever is actually in
+    front. This module posts CGEvents, so it keeps the on-screen default.
 
     Windows are matched by the owner PID of the com.apple.ScreenContinuity
     process, never by kCGWindowOwnerName. The owner name is localized — macOS
@@ -38,24 +44,32 @@ def find_window():
     if app is None:
         return None                     # not running, so it owns no windows
     pid = app.processIdentifier()
-    wins = Quartz.CGWindowListCopyWindowInfo(
-        Quartz.kCGWindowListOptionOnScreenOnly, Quartz.kCGNullWindowID) or []
-    for w in wins:
-        if w.get("kCGWindowOwnerPID") == pid and w.get("kCGWindowLayer", 1) == 0:
-            b = w["kCGWindowBounds"]
-            # No size filter. The old `Width < 100` guard was there to skip
-            # panels and toolbars, but PID + on-screen + layer 0 already
-            # excludes those: the app's other windows (Settings, Welcome, and
-            # four unnamed 1512x33 strips) are never in the on-screen list, so
-            # this loop sees exactly one candidate. What the guard did hit was
-            # a real mirroring window that macOS had shrunk — with Stage
-            # Manager on, an inactive window is parked in the left rail at
-            # about 38x130, which is on-screen and genuinely the phone. The
-            # guard discarded it, so every time another app took the stage the
-            # harness reported a disconnected phone (#8). Window list order is
-            # front to back, so the first match is the frontmost.
-            return {"x": b["X"], "y": b["Y"], "w": b["Width"], "h": b["Height"],
-                    "id": int(w["kCGWindowNumber"])}
+    opts = (Quartz.kCGWindowListOptionOnScreenOnly if on_screen
+            else Quartz.kCGWindowListOptionAll)
+    wins = Quartz.CGWindowListCopyWindowInfo(opts, Quartz.kCGNullWindowID) or []
+    cands = [w for w in wins if w.get("kCGWindowOwnerPID") == pid
+             and w.get("kCGWindowLayer", 1) == 0]
+    if not on_screen:
+        # Off the active Space the list also carries the app's other windows:
+        # a Settings sheet, a Welcome dialog, and four unnamed 1512x33 strips.
+        # The phone window is the one whose title is the app's own name. Both
+        # strings are localized together, so this still picks it out where a
+        # comparison against the English constant would not.
+        named = [w for w in cands
+                 if w.get("kCGWindowName") == w.get("kCGWindowOwnerName")]
+        cands = named or cands
+    # No size filter. The old `Width < 100` guard was there to skip panels and
+    # toolbars, but PID + layer 0 already excludes those. What the guard did
+    # hit was a real mirroring window that macOS had shrunk — with Stage
+    # Manager on, an inactive window is parked in the left rail at about
+    # 38x130, which is on-screen and genuinely the phone. The guard discarded
+    # it, so every time another app took the stage the harness reported a
+    # disconnected phone (#8). Window list order is front to back, so the
+    # first candidate is the frontmost.
+    for w in cands:
+        b = w["kCGWindowBounds"]
+        return {"x": b["X"], "y": b["Y"], "w": b["Width"], "h": b["Height"],
+                "id": int(w["kCGWindowNumber"])}
     return None
 
 

--- a/src/phone_harness/mirror.py
+++ b/src/phone_harness/mirror.py
@@ -115,6 +115,82 @@ def running_app():
     return apps[0] if apps else None
 
 
+def window_ax_content():
+    """Native UI drawn inside the mirroring window, as [(role, text)].
+
+    A connected session returns []. The phone image is a video stream and
+    accessibility cannot see into it — that is the same property that forces
+    the harness to read the screen with OCR.
+
+    The interstitials macOS draws in that window when the session is not
+    usable (iPhone in Use, paused, ended, locked, connect) are ordinary Mac
+    views, so they come back with their labels and buttons. Detecting them by
+    the presence of real UI rather than by searching for known phrases is what
+    makes this work on a non-English system, and on whatever screen Apple adds
+    next.
+
+    Observed: 0 elements live, 4 on "iPhone in Use". Button titles are not
+    dependable — the same screen reported 'Connect' once and an empty title a
+    minute later — so callers should read AXStaticText for anything shown to
+    a user.
+    """
+    app = running_app()
+    if app is None:
+        return []
+    win = find_window()
+    if win is None:
+        return []
+    err, ax_wins = _AS.AXUIElementCopyAttributeValue(
+        _AS.AXUIElementCreateApplication(app.processIdentifier()),
+        "AXWindows", None)
+    if err or not ax_wins:
+        return []
+
+    def geom(node):
+        e1, pos = _AS.AXUIElementCopyAttributeValue(node, "AXPosition", None)
+        e2, size = _AS.AXUIElementCopyAttributeValue(node, "AXSize", None)
+        if e1 or e2 or pos is None or size is None:
+            return None
+        ok, p = _AS.AXValueGetValue(pos, _AS.kAXValueCGPointType, None)
+        ok2, sz = _AS.AXValueGetValue(size, _AS.kAXValueCGSizeType, None)
+        return (p.x, p.y, sz.width, sz.height) if ok and ok2 else None
+
+    # Match the phone window by geometry. The app also owns a Settings sheet
+    # and a Welcome dialog; counting their contents would report a healthy
+    # session as blocked.
+    target = None
+    for w in ax_wins:
+        g = geom(w)
+        if g and abs(g[0] - win["x"]) < 4 and abs(g[1] - win["y"]) < 4 \
+                and abs(g[2] - win["w"]) < 4 and abs(g[3] - win["h"]) < 4:
+            target = w
+            break
+    if target is None:
+        return []
+
+    out = []
+
+    def walk(node, depth=0):
+        if depth > 6 or len(out) > 40:
+            return
+        e, role = _AS.AXUIElementCopyAttributeValue(node, "AXRole", None)
+        role = "" if e else str(role)
+        if role in ("AXStaticText", "AXButton", "AXTextField",
+                    "AXSecureTextField", "AXImage"):
+            parts = []
+            for attr in ("AXTitle", "AXValue", "AXDescription"):
+                ea, v = _AS.AXUIElementCopyAttributeValue(node, attr, None)
+                if not ea and isinstance(v, str) and v.strip():
+                    parts.append(v.strip())
+            out.append((role, " ".join(parts)))
+        ek, kids = _AS.AXUIElementCopyAttributeValue(node, "AXChildren", None)
+        for k in (kids or []):
+            walk(k, depth + 1)
+
+    walk(target)
+    return out
+
+
 def frontmost_window():
     """The frontmost normal-layer window, or None — i.e. *which* app is in
     front. Queried live from the window list, which needs no run loop."""

--- a/src/phone_harness/mirror.py
+++ b/src/phone_harness/mirror.py
@@ -22,11 +22,24 @@ TMP.mkdir(exist_ok=True)
 # --- window / app state ---
 
 def find_window():
-    """{x, y, w, h, id} of the mirroring window in screen points, or None."""
+    """{x, y, w, h, id} of the mirroring window in screen points, or None.
+
+    Windows are matched by the owner PID of the com.apple.ScreenContinuity
+    process, never by kCGWindowOwnerName. The owner name is localized — macOS
+    reports "iPhone镜像" on a Simplified Chinese system and "iPhone鏡像輸出" on
+    a Traditional Chinese one — so an equality test against the English
+    APP_NAME finds nothing, and the harness reports a permanently disconnected
+    phone on any non-English Mac. The bundle id behind running_app() is never
+    localized.
+    """
+    app = running_app()
+    if app is None:
+        return None                     # not running, so it owns no windows
+    pid = app.processIdentifier()
     wins = Quartz.CGWindowListCopyWindowInfo(
         Quartz.kCGWindowListOptionOnScreenOnly, Quartz.kCGNullWindowID) or []
     for w in wins:
-        if w.get("kCGWindowOwnerName") == APP_NAME and w.get("kCGWindowLayer", 1) == 0:
+        if w.get("kCGWindowOwnerPID") == pid and w.get("kCGWindowLayer", 1) == 0:
             b = w["kCGWindowBounds"]
             if b["Width"] < 100:  # ignore panels/toolbars
                 continue

--- a/src/phone_harness/mirror.py
+++ b/src/phone_harness/mirror.py
@@ -11,7 +11,7 @@ import ApplicationServices as _AS
 from pathlib import Path
 
 import Quartz
-from AppKit import NSRunningApplication, NSWorkspace
+from AppKit import NSRunningApplication
 
 APP_NAME = "iPhone Mirroring"
 BUNDLE_ID = "com.apple.ScreenContinuity"
@@ -115,21 +115,65 @@ def running_app():
     return apps[0] if apps else None
 
 
+def frontmost_window():
+    """The frontmost normal-layer window, or None — i.e. *which* app is in
+    front. Queried live from the window list, which needs no run loop."""
+    wins = Quartz.CGWindowListCopyWindowInfo(
+        Quartz.kCGWindowListOptionOnScreenOnly
+        | Quartz.kCGWindowListExcludeDesktopElements,
+        Quartz.kCGNullWindowID) or []
+    for w in wins:                      # front-to-back order
+        if w.get("kCGWindowLayer", 1) == 0:
+            return w
+    return None
+
+
 def is_frontmost():
-    front = NSWorkspace.sharedWorkspace().frontmostApplication()
-    return bool(front and front.bundleIdentifier() == BUNDLE_ID)
+    """Does iPhone Mirroring have keyboard focus.
+
+    Reads AXFrontmost through focus_probe(), not
+    NSWorkspace.frontmostApplication(): that value arrives by workspace
+    notification, and a process with no run loop never receives one, so it
+    reports whatever was true when the process first looked. Believing it is
+    how input ends up in the wrong app — activate() sees a stale "already
+    frontmost", skips focusing, and every CGEvent after that lands in
+    whatever the user actually has focused.
+
+    Focus is asked for directly rather than inferred from window order.
+    Measured on a real steal, AXFrontmost reported iPhone Mirroring while the
+    frontmost window still belonged to the user's terminal: the app had taken
+    the keyboard without moving a window. Reading z-order alone would have
+    called that no change, which is precisely the case worth catching.
+    """
+    return bool(focus_probe()[0])
 
 
-def activate():
-    """Bring iPhone Mirroring frontmost. Does NOT launch it — opening the app
-    and connecting the phone is the user's job, not the agent's."""
+def activate(timeout=2.5):
+    """Bring iPhone Mirroring frontmost and *confirm* it. Does NOT launch it —
+    opening the app and connecting the phone is the user's job, not the agent's.
+
+    Raises rather than returning unfocused: a silent failure here means every
+    subsequent tap and drag is delivered to some other app, which is both
+    confusing to debug and potentially destructive.
+    """
     app = running_app()
     if app is None:
         raise RuntimeError(
             f"{APP_NAME} isn't running — open it and connect your phone.")
-    if not is_frontmost():
-        app.activateWithOptions_(1 << 1)  # NSApplicationActivateIgnoringOtherApps
-        time.sleep(0.5)
+    if is_frontmost():
+        return
+    app.activateWithOptions_(1 << 1)  # NSApplicationActivateIgnoringOtherApps
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        time.sleep(0.05)
+        if is_frontmost():
+            return
+    win = frontmost_window() or {}
+    owner = win.get("kCGWindowOwnerName", "unknown")
+    raise RuntimeError(
+        f"could not bring {APP_NAME} frontmost after {timeout:.1f}s — "
+        f"{owner!r} still has focus. Input would be swallowed, so nothing "
+        f"was sent.")
 
 
 def ensure_window(timeout=5.0):

--- a/src/phone_harness/mirror.py
+++ b/src/phone_harness/mirror.py
@@ -6,6 +6,8 @@ macOS accessibility sees nothing inside it, so input is synthesized at the
 HID level and the window must be frontmost or events are swallowed.
 """
 import subprocess, tempfile, time
+
+import ApplicationServices as _AS
 from pathlib import Path
 
 import Quartz
@@ -55,6 +57,57 @@ def find_window():
             return {"x": b["X"], "y": b["Y"], "w": b["Width"], "h": b["Height"],
                     "id": int(w["kCGWindowNumber"])}
     return None
+
+
+def focus_probe():
+    """(app_frontmost, depth) — the two interruptions a user actually notices.
+
+    app_frontmost  does iPhone Mirroring have keyboard focus / the menu bar.
+                   Read from the accessibility API, which reports it live.
+                   NSWorkspace.frontmostApplication() cannot be used: it is
+                   delivered by a workspace notification, and a process with no
+                   run loop never receives one — measured returning the same
+                   stale pid across two deliberate app switches.
+    depth          our window's index in the front-to-back on-screen window
+                   list, so 0 means nothing is drawn over it and None means it
+                   is not on screen at all.
+
+    The two are read from different sources on purpose. Deriving focus from
+    z-order makes "took focus but stayed behind" unrepresentable, which is
+    exactly the state worth telling apart from "jumped in front".
+    """
+    app = running_app()
+    if app is None:
+        return None, None
+    pid = app.processIdentifier()
+    el = _AS.AXUIElementCreateApplication(pid)
+    err, val = _AS.AXUIElementCopyAttributeValue(el, "AXFrontmost", None)
+    front = None if err else bool(val)
+    wins = Quartz.CGWindowListCopyWindowInfo(
+        Quartz.kCGWindowListOptionOnScreenOnly, Quartz.kCGNullWindowID) or []
+    layer0 = [w for w in wins if w.get("kCGWindowLayer", 1) == 0]
+    depth = next((i for i, w in enumerate(layer0)
+                  if w.get("kCGWindowOwnerPID") == pid), None)
+    return front, depth
+
+
+def interruption(before, after):
+    """{raised, stole_focus} between two focus_probe() readings.
+
+    Raises when either reading has no focus value rather than reporting a
+    clean result. AXFrontmost errors when Accessibility permission is missing,
+    and a probe that silently answers "nothing happened" because it could not
+    look is worse than no probe at all.
+    """
+    b_front, b_depth = before
+    a_front, a_depth = after
+    if b_front is None or a_front is None:
+        raise RuntimeError(
+            "focus_probe() could not read AXFrontmost — grant the terminal "
+            "Accessibility permission. Refusing to report an unmeasured "
+            "result as no interruption.")
+    raised = a_depth is not None and (b_depth is None or a_depth < b_depth)
+    return {"raised": bool(raised), "stole_focus": bool(a_front and not b_front)}
 
 
 def running_app():


### PR DESCRIPTION
Six fixes for cases where the harness reported something untrue about the phone or the Mac.

Each commit was verified against a control run on `main`, on a real device.

## What's fixed

**Window discovery**
- `find_window()` compared `kCGWindowOwnerName` against the English `"iPhone Mirroring"`. macOS localizes that name, so on a non-English Mac it matched nothing and the harness reported a permanently disconnected phone. Now matched by owner PID, which is never localized.
- The `Width < 100` guard was discarding the real window when Stage Manager parked it in the rail at ~38x130. PID + layer 0 already excludes panels, so the guard only ever rejected genuine windows.

**Focus**
- `is_frontmost()` read `NSWorkspace.frontmostApplication()`, which arrives by workspace notification — a process with no run loop never receives one. Measured across three states, it returned the same pid every time, including right after a successful activation. Since `activate()` was written as `if not is_frontmost(): activate...`, a stale "already frontmost" skipped focusing entirely and every CGEvent afterwards landed in whatever app the user actually had focused.
- `focus_probe()` reports the two things a user notices: did Mirroring take keyboard focus (AXFrontmost), and did its window come forward (window-list order). Kept as separate sources — measured on a real steal, AX reported Mirroring focused while the frontmost window still belonged to the user's terminal. Inferring focus from z-order calls that no change.
- `activate()` now confirms it worked and names the blocking app instead of returning unfocused.

**Dead sessions**
- `connection_state()` looked for known phrases in OCR. It returned `ready` for "Connection Paused" and for the Mac login screen, so an agent mid-task kept tapping and typing into a password field.
- The live phone image is a video stream that accessibility cannot see into; the interstitials are ordinary Mac views. So a connected session exposes no UI inside the window and a blocked one exposes labels and a button — 0 elements vs 4, measured. No text involved, so it holds in any language.
- The phrase list stays as a fallback; only one interstitial is confirmed structurally so far.

**Docs**
- Dropped the "don't linger in personal content" line. "Linger" was undefined and the parenthetical list implied unlisted apps were unrestricted; in practice it produced wrong behaviour in both directions.

## Closes / supersedes

Closes #5, #13 (the localized-name half), and the Stage Manager half of #8.
Supersedes #2, #9, #10, #16.

#16's live window-list read is kept as `frontmost_window()` — it answers *which* app is in front, which is what makes the failure message actionable. Only the focus test moved to AX.

## Not covered

- The hidden / off-Space / minimized half of #8. Parked on `wip/hidden-window-support`: it makes the task survive, but input surfaces the window, and that tradeoff needs deciding separately.
- Only the "iPhone in Use" interstitial is confirmed structurally. The others are presumed identical.

## Credits

Found and diagnosed by contributors whose PRs and issues this supersedes — thank you:

- **@z5840415** (#1, #2) — spotted the nonexistent `pyobjc-framework-AppKit` dependency, and the localized-name window-discovery bug.
- **@Unayung** (#9) — independently found the AppKit dependency and the non-English window-discovery break.
- **@joseedson18jc** (#11) — independently found the AppKit dependency (plus PEP 668 and pull-to-refresh notes still open on #11).
- **@r3n3x** (#8) — filed the Stage Manager / off-screen window report with the exact geometry used here.
- **@rian-chaudhry** (#5) — filed the reproduction for `connection_state()` returning `ready` on the Mac-login lock screen.
- **@deijing** (#13) — reported the localized iPhone Mirroring app-name breakage.

Where the merged fix adopts a contributor's approach directly (AppKit → Cocoa, PID-based window matching), `Co-authored-by:` trailers will be added at squash-merge.