### PR TITLE
Interactivity: real modifier keys, and paste instead of typing

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -92,7 +92,12 @@ raises a clear message (call `connection_state()` yourself to check —
   tap through the resume screen — stop and ask the user to lock/connect the
   phone (see "Connection is the user's job").
 - **`type_text` needs an iOS text field focused first** — tap the field, wait
-  for the keyboard, then type.
+  for the keyboard, then type. It fails *silently* when nothing is focused: the
+  text goes to whatever is focused instead, or nowhere. Verify with a capture,
+  and if a tap will not take focus, `press("tab")` moves between fields.
+- **`type_text` pastes; it does not type.** That is deliberate — the keystroke
+  path runs through iOS autocorrect, which rewrites words as they land ("Thu"
+  becomes "thru"). Pass `keystrokes=True` for fields that need real key events.
 - **Home-Screen labels are not tap targets.** `tap_text("Weather")` hits the
   label and nothing happens; the icon is ~35 points above it. Use
   `tap_icon("Weather")` (agent helper) on the Home Screen; `tap_text` works

--- a/SKILL.md
+++ b/SKILL.md
@@ -27,8 +27,11 @@ PY
 
 - Invoke as `phone-harness`. Use heredocs for multi-line commands.
 - Helpers are pre-imported. All coordinates are global screen points.
-- `ensure_mirroring()` launches and focuses the window; input helpers focus it
-  automatically before posting events.
+- `ensure_mirroring()` launches the window and gates on connection. The
+  default build then works the phone **without focusing it**: capture is by
+  window id and input is an event record delivered straight to the app, so a
+  task never steals the user's screen. `PHONE_HARNESS_BACKGROUND=0` forces the
+  classic path, which must focus before every action.
 
 ## Screen Workflow
 
@@ -53,10 +56,14 @@ PY
   new rows — a dense screen or a missed OCR line will not end the scroll
   early. Each step settles first so lazy-loaded content arrives before the
   movement check. `scroll_screen()` is the single-step primitive if you need
-  it. These use wheel scrolling (a slow touch-drag barely moves an iOS list
-  and bounces back).
+  it. In the background build these scroll with momentum flicks — wheel
+  events only route to a *focused* window, and a slow touch-drag barely moves
+  an iOS list before bouncing back; only a fast flick carries it.
 - Raw Quartz is the escape hatch: `import Quartz` in your script for anything
-  the helpers don't cover.
+  the helpers don't cover — but raw CGEvents don't ride the helpers' delivery
+  path. They land only while the window is frontmost and are swallowed
+  silently otherwise, scroll-wheel events included: `activate()` first, then
+  verify the screen actually changed.
 
 ## Consent
 
@@ -82,8 +89,13 @@ raises a clear message (call `connection_state()` yourself to check —
 
 ## Gotchas
 
-- **Unfocused input is swallowed silently.** The window must be frontmost;
-  helpers call `activate()` but if a click steals focus mid-task, re-activate.
+- **Unfocused input is swallowed silently — for events you post yourself.**
+  The helpers are immune in the background build (input goes straight to the
+  app), but raw CGEvents and the `PHONE_HARNESS_BACKGROUND=0` path need the
+  window frontmost: `activate()` before posting, and re-activate if a click
+  steals focus mid-task. The failure looks exactly like "scrolling is broken"
+  or "the list already ended" — when a gesture changes nothing on screen,
+  check focus before inventing another theory.
 - **The window is a video stream.** macOS accessibility sees nothing inside
   it; AppleScript `click at` fails silently. Only HID-level CGEvents work.
 - **The window moves.** Never cache coordinates across calls; `ocr()` and

--- a/install.md
+++ b/install.md
@@ -7,7 +7,7 @@ Use once. For phone work, read `SKILL.md`.
 - macOS Sequoia+ with iPhone Mirroring paired to the phone (open the app once
   manually to pair — pairing prompts need the physical phone).
 - Python 3.12+ with pyobjc (`pip install pyobjc-framework-Quartz
-  pyobjc-framework-Vision pyobjc-framework-AppKit`).
+  pyobjc-framework-Vision`; AppKit is bundled with the macOS Python bridge here).
 - The terminal app needs two permissions in System Settings > Privacy &
   Security. **The toggles require the user:**
   - **Accessibility** — taps and keystrokes. Takes effect immediately.

--- a/src/phone_harness/background.py
+++ b/src/phone_harness/background.py
@@ -35,6 +35,7 @@ event-record layout isn't implemented yet, so those fall back to the mirror
 path. Mouse actions are fully background.
 """
 import ctypes, ctypes.util, os, struct, subprocess, tempfile, time
+from contextlib import contextmanager
 from pathlib import Path
 
 import Quartz
@@ -259,14 +260,41 @@ def _make_key(pid, wid):
     _sky.SLPSPostEventRecordTo(ctypes.byref(psn), ctypes.byref(buf))
 
 
+def _key_edge(pid, wid, code, down, flags=0):
+    _make_key(pid, wid)                 # keep the window key across the keystroke
+    ev = Quartz.CGEventCreateKeyboardEvent(None, code, down)
+    if flags:
+        # Mac-side consumers only. iPhone Mirroring forwards raw HID keycodes
+        # to iOS and drops the flag mask, so a modifier expressed as a flag
+        # never reaches the phone — it has to be a key that is held.
+        Quartz.CGEventSetFlags(ev, flags)
+    Quartz.CGEventPostToPid(pid, ev)
+    time.sleep(0.03)
+
+
 def _key(pid, wid, code, flags=0):
     for down in (True, False):
-        _make_key(pid, wid)             # keep the window key across the keystroke
-        ev = Quartz.CGEventCreateKeyboardEvent(None, code, down)
-        if flags:
-            Quartz.CGEventSetFlags(ev, flags)
-        Quartz.CGEventPostToPid(pid, ev)
-        time.sleep(0.03)
+        _key_edge(pid, wid, code, down, flags)
+
+
+@contextmanager
+def _holding(pid, wid, mods):
+    """Hold real modifier keys down around the body. See mirror._holding."""
+    acc = 0
+    for m in mods:
+        acc |= mirror._MODIFIERS[m]
+        _key_edge(pid, wid, mirror._MOD_KEYCODES[m], True, acc)
+    try:
+        yield acc
+    finally:
+        # Unconditional: a latched modifier corrupts every later keystroke, and
+        # the damage surfaces somewhere else entirely.
+        for m in reversed(mods):
+            # Clear the bit *before* posting the release. A key-up still
+            # carrying its own flag reads as "still held", which latches shift
+            # on and turns the rest of the string into 1,200 -> !<@)).
+            acc &= ~mirror._MODIFIERS[m]
+            _key_edge(pid, wid, mirror._MOD_KEYCODES[m], False, acc)
 
 
 def press(combo):
@@ -276,14 +304,16 @@ def press(combo):
     key, mods = parts[-1], parts[:-1]
     if key not in mirror._KEYCODES:
         raise ValueError(f"unknown key {key!r}")
-    flags = 0
     for m in mods:
-        flags |= mirror._MODIFIERS[m]
-    _key(pid, win["id"], mirror._KEYCODES[key], flags)
+        if m not in mirror._MOD_KEYCODES:
+            raise ValueError(f"unknown modifier {m!r}")
+    with _holding(pid, win["id"], mods) as flags:
+        _key(pid, win["id"], mirror._KEYCODES[key], flags)
 
 
-def type_text(text, delay=0.03):
-    """Type into the focused iOS field via real keycodes, no focus change."""
+def _type_keystrokes(text, delay=0.03):
+    """Type via real keycodes, no focus change. Subject to iOS autocorrect,
+    which rewrites words as they are typed."""
     pid, win = _ctx()
     for i, line in enumerate(text.split("\n")):
         if i:
@@ -292,6 +322,17 @@ def type_text(text, delay=0.03):
             code, shifted = mirror._keycode_for(ch)
             if code is None:
                 raise ValueError(f"cannot type {ch!r} via keycodes")
-            _key(pid, win["id"], code,
-                 Quartz.kCGEventFlagMaskShift if shifted else 0)
+            with _holding(pid, win["id"], ["shift"] if shifted else []) as flags:
+                _key(pid, win["id"], code, flags)
             time.sleep(delay)
+
+
+def type_text(text, delay=0.03, keystrokes=False):
+    """Type into the focused iOS field, no focus change.
+
+    Pastes by default so the text arrives exactly as written, past autocorrect
+    and keyboard layout both. keystrokes=True sends real key events instead.
+    """
+    if keystrokes or not text:
+        return _type_keystrokes(text, delay)
+    mirror.paste_with(press, text)

--- a/src/phone_harness/helpers.py
+++ b/src/phone_harness/helpers.py
@@ -214,10 +214,14 @@ def press(combo):
     return send("input.keys", combo=combo)
 
 
-def type_text(text, delay=0.03):
+def type_text(text, delay=0.03, keystrokes=False):
     """Type into the focused field. Tap the field and let the keyboard appear
-    first — text sent before it has focus goes nowhere."""
-    return send("input.text", s=text, delay=delay)
+    first — text sent before it has focus goes nowhere, silently, so check a
+    capture afterwards.
+
+    Pastes by default so the text arrives exactly as written; keystrokes=True
+    sends real key events for fields that need them."""
+    return send("input.text", s=text, delay=delay, keystrokes=keystrokes)
 
 
 # --- gestures relative to the screen ----------------------------------------

--- a/src/phone_harness/helpers.py
+++ b/src/phone_harness/helpers.py
@@ -97,6 +97,33 @@ def screenshot(path=None):
     return p
 
 
+def image_point(x, y, image_size=None):
+    """Convert a screenshot pixel point to a global screen point.
+
+    Pass the pixel coordinates observed in the most recent screenshot. The
+    current window and capture size are queried every call so window movement,
+    resizing, and Retina/non-Retina captures are handled correctly.
+    """
+    info = screen_info()
+    iw, ih = image_size or info["img_px"]
+    win = info["window"]
+    if iw <= 0 or ih <= 0:
+        raise ValueError("image dimensions must be positive")
+    return (win["x"] + x * win["w"] / iw,
+            win["y"] + y * win["h"] / ih)
+
+
+def tap_image_point(x, y, image_size=None):
+    """Tap a point identified in screenshot pixel coordinates.
+
+    This is for icon-only controls that OCR cannot locate. It converts the
+    point using the current window geometry, then sends the normal tap event.
+    """
+    gx, gy = image_point(x, y, image_size=image_size)
+    tap(gx, gy)
+    return {"image": {"x": x, "y": y}, "screen": {"x": gx, "y": gy}}
+
+
 # --- did we interrupt the user ----------------------------------------------
 
 def focus_probe():

--- a/src/phone_harness/ios.py
+++ b/src/phone_harness/ios.py
@@ -98,8 +98,8 @@ class IPhone(Backend):
     def _input_keys(self, combo):
         self.mirror.press(combo)
 
-    def _input_text(self, s, delay=0.03):
-        self.mirror.type_text(s, delay=delay)
+    def _input_text(self, s, delay=0.03, keystrokes=False):
+        self.mirror.type_text(s, delay=delay, keystrokes=keystrokes)
 
     # --- navigation -----------------------------------------------------
 
@@ -117,7 +117,10 @@ class IPhone(Backend):
         """Spotlight (Cmd+3): type the name, let results populate, commit."""
         self.mirror.press("cmd+3")
         _sleep(0.9)
-        self.mirror.type_text(name)
+        # Keystrokes on purpose: Spotlight is the load-bearing path behind
+        # open_app and demonstrably works this way. Move it to paste only once
+        # that path has miles on it.
+        self.mirror.type_text(name, keystrokes=True)
         _sleep(1.2)
         self.mirror.press("return")
         return name

--- a/src/phone_harness/mirror.py
+++ b/src/phone_harness/mirror.py
@@ -6,6 +6,7 @@ macOS accessibility sees nothing inside it, so input is synthesized at the
 HID level and the window must be frontmost or events are swallowed.
 """
 import subprocess, tempfile, time
+from contextlib import contextmanager
 
 import ApplicationServices as _AS
 from pathlib import Path
@@ -402,6 +403,52 @@ _MODIFIERS = {
     "option": Quartz.kCGEventFlagMaskAlternate,
     "ctrl": Quartz.kCGEventFlagMaskControl,
 }
+# The physical keys behind those flags. Left-hand only: a synthesized event has
+# no physical side, so kVK_RightShift and friends (54, 60, 61, 62) would be dead
+# weight. kVK_CapsLock (57) is left out on purpose — it is a toggle with its own
+# flag mask and synthesizes unreliably, and shift covers every case we want.
+_MOD_KEYCODES = {
+    "cmd": 55, "shift": 56, "alt": 58, "option": 58, "ctrl": 59,
+}
+
+
+def _post_key(code, down, flags=0):
+    ev = Quartz.CGEventCreateKeyboardEvent(None, code, down)
+    if flags:
+        # Only Mac-side consumers ever read these. Set them so macOS's own
+        # state machine stays consistent; iOS never sees them.
+        Quartz.CGEventSetFlags(ev, flags)
+    Quartz.CGEventPost(Quartz.kCGHIDEventTap, ev)
+
+
+@contextmanager
+def _holding(mods):
+    """Hold real modifier keys down around the body.
+
+    iPhone Mirroring forwards raw HID keycodes to iOS and drops the CGEvent
+    flag mask, so a flag set on the key event reaches the Mac app but never the
+    phone. That is why cmd+1 (a menu shortcut the Mac app handles) works while
+    cmd+v aimed at an iOS text field arrives as a bare 'v'. Shift is a key you
+    hold, not a bit you set.
+    """
+    acc = 0
+    for m in mods:
+        acc |= _MODIFIERS[m]
+        _post_key(_MOD_KEYCODES[m], True, acc)
+        time.sleep(0.01)
+    try:
+        yield acc
+    finally:
+        # Unconditional: a modifier left latched by an exception mid-string
+        # corrupts every later keystroke in the session, and the damage shows
+        # up somewhere else entirely.
+        for m in reversed(mods):
+            # Clear the bit *before* posting the release. A key-up still
+            # carrying its own flag reads as "still held", which latches shift
+            # on and turns the rest of the string into 1,200 -> !<@)).
+            acc &= ~_MODIFIERS[m]
+            _post_key(_MOD_KEYCODES[m], False, acc)
+            time.sleep(0.01)
 
 
 def press(combo):
@@ -411,15 +458,13 @@ def press(combo):
     key, mods = parts[-1], parts[:-1]
     if key not in _KEYCODES:
         raise ValueError(f"unknown key {key!r}")
-    flags = 0
     for m in mods:
-        flags |= _MODIFIERS[m]
-    for down in (True, False):
-        ev = Quartz.CGEventCreateKeyboardEvent(None, _KEYCODES[key], down)
-        if flags:
-            Quartz.CGEventSetFlags(ev, flags)
-        Quartz.CGEventPost(Quartz.kCGHIDEventTap, ev)
-        time.sleep(0.03)
+        if m not in _MOD_KEYCODES:
+            raise ValueError(f"unknown modifier {m!r}")
+    with _holding(mods) as flags:
+        for down in (True, False):
+            _post_key(_KEYCODES[key], down, flags)
+            time.sleep(0.03)
 
 
 # iPhone Mirroring forwards raw HID keycodes to iOS and ignores the unicode
@@ -448,9 +493,35 @@ def _keycode_for(ch):
     return code, shifted
 
 
-def type_text(text, delay=0.03):
-    """Type text into the focused iOS field via real keycodes (US layout).
-    \n presses return. Raises on characters with no keycode (emoji etc.)."""
+def paste_with(press_fn, text):
+    """Put text on the Mac clipboard and paste it into the phone.
+
+    Takes the press function rather than calling one, because the two input
+    paths reach the phone differently (posted to the window vs posted to the
+    pid) and only the caller knows which is in play. The clipboard round-trip
+    itself is identical, and worth having in exactly one place.
+    """
+    prior = subprocess.run(["pbpaste"], capture_output=True).stdout
+    try:
+        subprocess.run(["pbcopy"], input=text.encode())
+        # Fail here rather than pasting stale clipboard contents into the phone.
+        if subprocess.run(["pbpaste"], capture_output=True).stdout != text.encode():
+            raise RuntimeError("clipboard did not take the text; cannot paste")
+        time.sleep(0.15)   # the Mac clipboard has to reach the phone
+        press_fn("cmd+v")
+        time.sleep(0.2)    # and the paste has to land before we restore it
+    finally:
+        subprocess.run(["pbcopy"], input=prior)
+
+
+def _type_keystrokes(text, delay=0.03):
+    """Type via real keycodes (US layout). Newline presses return. Raises on
+    characters with no keycode (emoji etc.).
+
+    Subject to iOS autocorrect, which rewrites words as they are typed --
+    'Thu' becomes 'thru', 'Fri' becomes 'Friday'. Prefer type_text's paste
+    path for anything whose exact wording matters.
+    """
     _focus()
     for i, line in enumerate(text.split("\n")):
         if i:
@@ -459,10 +530,24 @@ def type_text(text, delay=0.03):
             code, shifted = _keycode_for(ch)
             if code is None:
                 raise ValueError(f"cannot type {ch!r} via keycodes")
-            for down in (True, False):
-                ev = Quartz.CGEventCreateKeyboardEvent(None, code, down)
-                if shifted:
-                    Quartz.CGEventSetFlags(ev, Quartz.kCGEventFlagMaskShift)
-                Quartz.CGEventPost(Quartz.kCGHIDEventTap, ev)
-                time.sleep(0.01)
+            with _holding(["shift"] if shifted else []) as flags:
+                for down in (True, False):
+                    _post_key(code, down, flags)
+                    time.sleep(0.01)
             time.sleep(delay)
+
+
+def type_text(text, delay=0.03, keystrokes=False):
+    """Type text into the focused iOS field.
+
+    Pastes by default, which is immune to both autocorrect and keyboard layout
+    -- the text arrives exactly as given. Set keystrokes=True for fields that
+    need real key events.
+
+    Either path needs a focused field. Neither can tell whether it got one:
+    text sent to an unfocused field goes nowhere, silently, so verify with a
+    capture afterwards.
+    """
+    if keystrokes or not text:
+        return _type_keystrokes(text, delay)
+    paste_with(press, text)

--- a/src/phone_harness/transport.py
+++ b/src/phone_harness/transport.py
@@ -30,7 +30,13 @@ nothing in common — so the shared layer is this vocabulary instead.
     input.drag          x1, y1, x2, y2, duration, steps
     input.scroll        x, y, dy, steps             +dy scrolls content up
     input.keys          combo
-    input.text          s, delay
+    input.text          s, delay, keystrokes
+
+        input.text pastes by default, which is exact; keystrokes=True asks for
+        real key events instead. The distinction is in the vocabulary because
+        it changes what arrives: a keystroke path runs through the device's own
+        autocorrect and keyboard layout, a paste does not. Backends without a
+        shared clipboard may only support keystrokes.
 
         duration and steps stay in the vocabulary rather than being hidden. On
         iOS a fast short drag is a momentum flick and a slow one barely


### PR DESCRIPTION
Stacked on #19. Retarget as the stack merges.

The first PR in this stack that changes what the phone actually *receives* — #18 fixed what the harness sees, #19 restructured how it talks to devices, this fixes what it sends.

## Why

Found by sending a text message to a real leasing agent, which arrived as

```
hi jason - shawn pana ... otherwise; wed after 1, all day thru, or Friday morning. thanks1
```

No capitals, `:` as `;`, `!` as `1`, and two words rewritten. Nothing raised. That is the shape of the problem — every failure here is silent, and the agent has no way to know.

## Modifiers were flags, not keys

`press()` and `type_text()` set the modifier as a `CGEventFlags` mask on the key event:

```python
ev = Quartz.CGEventCreateKeyboardEvent(None, code, down)
if shifted:
    Quartz.CGEventSetFlags(ev, Quartz.kCGEventFlagMaskShift)
```

`mirror.py` already documented why that cannot work, one comment above:

> iPhone Mirroring forwards raw HID keycodes to iOS and ignores the unicode payload

It drops the *flags* for the same reason. iOS never sees a bitmask, it sees a keycode stream. Shift is keycode 56 — a key that is held.

The tell is that `cmd+1` works today while `cmd+v` typed a literal `v`. Cmd+1/2/3 are menu shortcuts consumed by the iPhone Mirroring **Mac app**, which reads flags normally. Anything meant for the **phone** takes the HID path, where they are gone. Same bug, two consumers — which is why it went unnoticed.

Both input paths now post real modifier keycodes around the keystroke, via a context manager so an exception mid-string cannot leave one latched. Left-hand keycodes only; `Right*` variants are dead weight for synthesized events and `CapsLock` is a toggle that synthesizes unreliably. Both omissions are commented as deliberate.

Note that `background.py` carries its own `press`/`type_text` — that is the live path in the background-by-default build, with `mirror.py` supplying only the keycode tables. Both are fixed. The clipboard logic lives once, in `mirror.paste_with`, which takes the press function because the two paths reach the phone differently (posted to the window vs. to the pid).

### The subtlety that cost a round

Clearing the flag on the *release* is required. A key-up still carrying its own bit reads as "still held":

```
Hi Jason: Thu & Fri - $1,200 (OK?)   ->   HI JASON: THU & FRI _ $!<@))
```

Shift latched on for the whole string. `acc &= ~mask` before posting the release fixes it. This only showed up on the device.

## Paste by default

`type_text` now pastes, with `keystrokes=True` for fields that need real key events. Paste is exact by construction: it does not depend on keyboard layout and cannot be rewritten by autocorrect on the way in. The clipboard is saved and restored, and a failed `pbcopy` raises rather than pasting stale contents into the phone.

Spotlight stays on `keystrokes=True`. It is the load-bearing path behind `open_app`, it demonstrably works that way, and it should not be migrated in the same change that fixes something else.

`input.text` gains `keystrokes` in the transport vocabulary, because it changes what arrives rather than how it is delivered — and a backend with no shared clipboard may only support one of them.

### Correction on autocorrect

An earlier draft of this PR claimed autocorrect was a second, independent bug, on the strength of `Thu`→`thru` and `Fri`→`Friday` in that message. **It does not reproduce once shift works.** Round-tripping the same words through the keystroke path in a Notes body now returns them exactly.

The likely explanation is that it was downstream of the shift bug all along: a dead shift key typed lowercase `thu`, which iOS corrected, whereas capitalized `Thu` is left alone. Autocorrect on the keystroke path is still a real exposure and a good reason to prefer paste, but this PR does not demonstrate it, and the justification for paste-by-default rests on exactness rather than on autocorrect.

## Verification

Round-tripped through both paths in a Notes body — a real editable field with autocorrect live — read back with OCR:

```
Hi Jason: Thu & Fri - $1,200 (OK?)
Wed after 1, all day Thu, or Fri morning.
```

Capitals, `:`, `&`, `$`, `,`, parens, `?`, a newline, and two autocorrect traps. Before: paste unreachable, keystrokes wrong on every count. After: both exact. `cmd+a` / `delete` now work as a clear. `open_app` re-verified.

## One thing found but not fixed here

**Taps would not focus the iMessage input field**; `press("tab")` did. The taps were landing — the compose button one row up worked — so it is not coordinate math. Cause unknown, not patched speculatively. `SKILL.md` now documents `tab` as the fallback and warns that `type_text` fails silently without focus, which is true regardless of the cause.


## Rider: SKILL.md catch-up on background-mode delivery (62ad249)

The skill still described the pre-background build — helpers focus before posting, scroll helpers "use wheel scrolling", raw Quartz offered with no caveat. All three predate bac4785's momentum flicks, which exist precisely because wheel events don't route to an unfocused window. Measured cost in a live session: an agent whose helper scrolls looked flaky dropped to raw wheel events, which died silently in an unfocused window — the symptom reads as "the list ended", and the fix was one `activate()`. Rides here because it's the same subject as this PR's other SKILL.md edits: what actually arrives, and which failures are silent.
