### PR TITLE
Skill: hard rules for Chinese UI, Home Screen safety, live-stream checks

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -1,14 +1,18 @@
 ---
 name: phone-harness
-description: "Control the user's iPhone through the Mac's iPhone Mirroring window: open apps, tap, type, swipe, read the screen."
+description: "Control the user's iPhone through the Mac's iPhone Mirroring window: open apps, tap, type, swipe, read the screen — background by default (no mouse/focus steal)."
 ---
 
 # phone-harness
 
 Direct iPhone control via the iPhone Mirroring app — screenshots + Vision OCR
-for eyes, HID-level CGEvents for hands. For task-specific edits, use
-`agent-workspace/agent_helpers.py`. For setup or permission problems, read
-`install.md`.
+for eyes; **SkyLight background input** for hands by default (does **not** steal
+the user's mouse or frontmost app). For task-specific helpers, use
+`agent-workspace/agent_helpers.py` (loaded into every `phone-harness` session).
+For setup or permission problems, read `install.md`.
+
+Upstream: https://github.com/ShawnPana/phone-harness  
+Background backend shipped 2026-08-10 (`background-input` + `background-by-default`).
 
 ## When Not to Use
 
@@ -17,53 +21,183 @@ web equivalent — do it there and leave the phone alone. Use phone-harness only
 when the task genuinely needs the phone: iOS-only apps, things tied to the
 user's phone number or 2FA, testing how something looks on the phone.
 
+## Hard rules (do not re-learn these by breaking the phone)
+
+### 1. Never delete, never jiggle-edit the Home Screen
+
+- **Forbidden:** deleting apps, tapping red ⊖ / minus badges, Confirm Delete,
+  rearranging icons "to clean up", entering edit mode on purpose.
+- Home Screen **jiggle mode** (icons wiggle, ⊖ badges, top bar 编辑/完成) is
+  almost always a mistake — caused by `long_press` on an icon, a sticky drag,
+  or a hold that was meant to be a tap.
+- On the Home Screen: **short `tap` only**. Do **not** call `long_press` on
+  icons/folders unless the user explicitly asked for a long-press action.
+- If jiggle/edit mode appears: **stop the task path**, call
+  `exit_home_edit_mode()` (agent helper), verify badges are gone via
+  `screenshot()`, then continue. Prefer tapping **完成** / Done; `home()` is
+  a backup. **Never** tap a red minus while exiting.
+- "Connection thrashing" (many swipes/long waits on the springboard) raises
+  the odds of accidental edit mode — keep Home Screen navigation minimal.
+
+### 2. `type_text` is ASCII / US-layout only — not Chinese
+
+- iPhone Mirroring forwards **HID keycodes**, not Unicode. `type_text("大众点评")`
+  raises `ValueError: cannot type '大' via keycodes`. Same for emoji and most
+  CJK / full-width punctuation.
+- For Spotlight / search fields when the target is Chinese:
+  - Prefer **Latin brand / pinyin ASCII** that Spotlight already indexes
+    (e.g. `dianping`, `meituan`, `wechat`) via `open_app("dianping")`.
+  - Or use `paste_text("…")` (agent helper: Mac clipboard + `cmd+v`) after
+    focusing the iOS field — requires Continuity clipboard / paste to work
+    on that device; verify with `ocr()`/`screenshot()` after paste.
+- Never invent a multi-step Chinese IME dance (switch keyboard, pinyin
+  candidate picks) unless the user asks and you have verified it works.
+
+### 3. Chinese UI: OCR is weak — you must read the screenshot image
+
+- Vision OCR often **garbles or drops Chinese** (Home Screen labels, Dianping,
+  WeChat, maps). English labels (YouTube, Gemini) survive; Chinese often becomes
+  noise like `BJL9` / `SE IOL`.
+- Workflow for any Chinese-heavy screen:
+  1. `path = screenshot()` (copy under the workspace if needed)
+  2. **Open/view the image** (do not rely on OCR text alone)
+  3. Tap by computed geometry from `screen_info()` (img px → global points)
+- Use `ocr()` as a helper for English strings and rough layout, not as ground
+  truth for Chinese app names or ticket titles.
+
+### 4. `connection_state() == ready` is not enough
+
+Before driving the phone, prove the stream shows **real phone content**:
+
+| Bad stream | Meaning | Action |
+|------------|---------|--------|
+| Window title like 欢迎使用 iPhone 镜像 / Welcome | Not paired / still on welcome | STOP — user must connect |
+| Screenshot pure black / empty OCR | Session paused, wrong window, or not streaming | STOP — user must reconnect / lock phone |
+| "iPhone in Use" / resume wall | Phone unlocked and stole the session | STOP — user locks phone |
+
+- Do **not** tap Connect / Continue yourself (see Connection section).
+- After the user says "connected", re-check with `screenshot()` + image view,
+  not only `connection_state()`.
+
+### 5. Opening apps
+
+| Method | When | Notes |
+|--------|------|--------|
+| `open_app("Notes")` | App has a **Latin** Spotlight name | `cmd+3` → type → return; keyboard briefly steals Mac focus |
+| `tap_icon("Weather")` | Home Screen, **OCR can read** the English/latin label | Taps ~35pt **above** the label |
+| `screenshot` + tap geometry | Chinese app name / OCR garbage / icon in a folder | Required for 大众点评-style apps if Spotlight miss |
+| Swipe Home pages | Last resort | Short `swipe("left")` only; no long-press; verify each page with **image**, not OCR alone |
+
+If Spotlight has no app hit (only Mail/Notes/App Store suggestions), the app is
+missing, renamed, or not indexed — **ask the user**, do not thrash every page
+into jiggle mode.
+
+### 6. Purchases and irreversible actions
+
+Stop on the **payment confirmation** screen. Do not complete pay, send messages,
+post, delete data, or change settings unless the user explicitly told you to
+finish that step after seeing the confirmation UI.
+
+## Background by default (do not steal focus)
+
+**Default transport is `phone_harness.background`.** Mouse taps, long-presses,
+drags, and scrolls are injected via private SkyLight `SLPSPostEventRecordTo`
+into the iPhone Mirroring process. Capture uses `CGWindowListCreateImage` by
+window id. Neither requires the mirroring window to be frontmost.
+
+| Action | Steals focus / mouse? |
+|--------|------------------------|
+| `screenshot` / `ocr` / `screen_info` | No |
+| `tap` / `long_press` / `drag` / `swipe` / `scroll*` | No |
+| `type_text` / `press` (keyboard) | **Briefly yes** — keyboard event-record not implemented yet; falls back to classic path |
+
+### Agent rules (mandatory)
+
+1. **Use only `phone-harness` helpers** (`tap`, `ocr`, …). Do **not** hand-roll
+   `CGEventPost`, `osascript … activate`, or AppleScript clicks for phone work.
+2. **Do not** call `osascript` / `NSWorkspace.activate` / `open -a "iPhone镜像"`
+   just to "make capture work". Background capture works unfocused when the
+   stream is healthy.
+3. **Do not** set `PHONE_HARNESS_BACKGROUND=0` unless the user asks, background
+   import failed, or background capture repeatedly returns nothing **while**
+   the user-confirmed stream is live (classic fallback steals focus — warn).
+4. Treat this like Kimi Cu cursor-safe clicks: the user's frontmost Mac app stays
+   theirs while you drive the phone.
+
+### Env switch
+
+```bash
+# default — background, no focus steal
+phone-harness <<'PY'
+print(screen_info())
+tap(x, y)
+PY
+
+# emergency only — classic CGEvent + frontmost (WILL steal mouse/focus)
+PHONE_HARNESS_BACKGROUND=0 phone-harness <<'PY'
+…
+PY
+```
+
+If the background backend fails to import (SkyLight symbols differ by macOS
+build), helpers auto-fall back to classic `mirror.py` and *will* focus the
+window. Check with:
+
+```bash
+phone-harness <<'PY'
+from phone_harness import helpers
+print("background=", helpers._BACKGROUND, "module=", helpers.mirror.__name__)
+PY
+```
+
 ## Usage
 
 ```bash
 phone-harness <<'PY'
 print(screen_info())
+print(connection_state())  # ready | blocked | no-window | not-running
+# then always: screenshot + view image before trusting the session
 PY
 ```
 
 - Invoke as `phone-harness`. Use heredocs for multi-line commands.
-- Helpers are pre-imported. All coordinates are global screen points.
-- `ensure_mirroring()` launches and focuses the window; input helpers focus it
-  automatically before posting events.
+- Helpers are pre-imported. All coordinates are **global screen points**.
+- Under the background backend, `activate()` is a **no-op**. Prefer
+  `connection_state()` / `ensure_mirroring()` over manually focusing the app.
+- Agent helpers (`tap_icon`, `exit_home_edit_mode`, `paste_text`, …) load from
+  `~/.phone-harness/agent-workspace/agent_helpers.py`.
 
 ## Screen Workflow
 
-- Prefer `ocr()` over eyeballing screenshots: every visible string comes back
-  with a tap-ready center point — `[{text, confidence, x, y, w, h}]`. Filter
-  in Python before printing.
+- Prefer `ocr()` for **English** chrome and rough layout; for Chinese, **view
+  the screenshot image** (see Hard rule 3).
 - Tap by label: `tap_text("Weather")`. On failure it raises with what IS
   visible, so read the exception before retrying.
-- Icons without labels: `screenshot()`, view the image, compute the point
-  (image px ÷ scale + window origin — `screen_info()` has both sizes), then
-  `tap(x, y)`.
-- **Verify after every action**: `wait_stable()` then `ocr()`/`screenshot()`.
-  There is no DOM to assert against; the capture is the ground truth.
-- Navigation: `home()`, `app_switcher()`, `open_app("Notes")` (Spotlight),
-  `swipe("up")`, `scroll()`, `type_text("...")`, `press("return")`,
-  `long_press(x, y)`.
+- Icons without reliable labels: `screenshot()`, view the image, compute the
+  point (image px ÷ scale + window origin — `screen_info()` has both sizes),
+  then `tap(x, y)`.
+- **Verify after every action**: short `wait` / `wait_stable()`, then
+  `screenshot()` (and `ocr()` when useful). Capture is the ground truth.
+- Navigation: `home()`, `app_switcher()`, `open_app("Notes")` (Spotlight,
+  Latin names only), `swipe("up")`, `scroll()`, `type_text("ascii...")`,
+  `paste_text("中文…")`, `press("return")`. Avoid `long_press` on Home Screen.
 - **Scrolling a list**: use `scroll_collect(extract, key=...)` to walk a list
   to its true end, de-duping as it goes — it returns `{items, stop, scrolls}`
   where `stop` is `'reached-end'` or `'max-scrolls'`. Use `scroll_until(done)`
   to stop when a predicate on the visible OCR is met. Both decide "done" from
   whether the **screen actually moved**, not from whether your parser found
-  new rows — a dense screen or a missed OCR line will not end the scroll
-  early. Each step settles first so lazy-loaded content arrives before the
-  movement check. `scroll_screen()` is the single-step primitive if you need
-  it. These use wheel scrolling (a slow touch-drag barely moves an iOS list
-  and bounces back).
-- Raw Quartz is the escape hatch: `import Quartz` in your script for anything
-  the helpers don't cover.
+  new rows. Background scroll uses **momentum flicks** (wheel events do not
+  route when unfocused).
+- Raw Quartz is the escape hatch only for non-input needs. **Never** replace
+  `tap`/`drag` with your own `CGEventPost` — that reintroduces focus steal.
 
 ## Consent
 
 This is the user's real phone. Stop and ask before anything outward-facing or
-hard to reverse: sending a message, posting, purchasing, deleting, changing
-settings. Navigating and reading for the user's own task is fine, but don't
-linger in personal content (Messages, Photos, Mail) beyond what the task needs.
+hard to reverse: sending a message, posting, purchasing, **deleting anything
+(including apps)**, changing settings. Navigating and reading for the user's
+own task is fine, but don't linger in personal content (Messages, Photos, Mail)
+beyond what the task needs.
 
 ## Connection is the user's job
 
@@ -80,23 +214,33 @@ raises a clear message (call `connection_state()` yourself to check —
   connection. Tapping Connect while the phone is unlocked does nothing, and
   polling just burns time — the only fix is the user locking/connecting the
   phone. Retry once *after they confirm they've done it*, not before.
+- Also STOP on black frames / welcome-title windows even if state says `ready`
+  (Hard rule 4).
 
 ## Gotchas
 
-- **Unfocused input is swallowed silently.** The window must be frontmost;
-  helpers call `activate()` but if a click steals focus mid-task, re-activate.
+- **Do not steal the user's Mac focus.** Stay on the background backend. No
+  `osascript activate`, no raw HID mouse injection outside helpers.
+- **Keyboard still steals briefly** (`type_text` / `press` / `paste_text`).
+  Warn if you will type a lot, or batch typing.
 - **The window is a video stream.** macOS accessibility sees nothing inside
-  it; AppleScript `click at` fails silently. Only HID-level CGEvents work.
+  it; AppleScript `click at` fails silently.
 - **The window moves.** Never cache coordinates across calls; `ocr()` and
   `swipe()` re-query bounds every time.
 - **Unlocking the physical phone pauses the session** ("iPhone in Use"). Do not
   tap through the resume screen — stop and ask the user to lock/connect the
   phone (see "Connection is the user's job").
 - **`type_text` needs an iOS text field focused first** — tap the field, wait
-  for the keyboard, then type.
+  for the keyboard, then type or paste. ASCII only for `type_text`.
 - **Home-Screen labels are not tap targets.** `tap_text("Weather")` hits the
   label and nothing happens; the icon is ~35 points above it. Use
   `tap_icon("Weather")` (agent helper) on the Home Screen; `tap_text` works
   fine for in-app buttons and list rows.
 - Mouse taps map to touches 1:1, but there is no multi-touch: no pinch, no
   two-finger gestures.
+- Capture can return empty if the mirroring window is tiny/off-screen or the
+  session is paused — that is a connection problem, not a cue to activate and
+  thrash the user's desktop or Home Screen.
+- **Background capture failed / classic works:** often means stream/permission
+  glitch or wrong window id — re-check connection with a screenshot; do not
+  spam Home swipes.

--- a/agent-workspace/agent_helpers.py
+++ b/agent-workspace/agent_helpers.py
@@ -5,6 +5,11 @@ load this file at import time; anything defined here is available in
 phone-harness scripts alongside the core helpers.
 """
 
+from __future__ import annotations
+
+import subprocess
+import time
+
 
 def tap_icon(label, index=0):
     """Tap a Home-Screen app icon by its label.
@@ -12,11 +17,143 @@ def tap_icon(label, index=0):
     Learned: tapping the label text itself does NOT launch the app in the
     mirrored Home Screen — the tappable icon is ~35 points above the label.
     Verified against Weather (label tap: no-op; icon tap: launches).
+
+    Only works when OCR can read the label (often fails for Chinese names).
+    For Chinese icons, screenshot + visual geometry tap instead.
     """
     from phone_harness.helpers import find_text, tap
+
     hits = find_text(label)
     if not hits:
         raise RuntimeError(f"no Home-Screen label matching {label!r}")
     h = hits[index]
     tap(h["x"], h["y"] - 35)
     return h
+
+
+def is_home_edit_mode(items=None):
+    """True if springboard jiggle/edit UI is visible (完成/编辑/⊖ style chrome)."""
+    from phone_harness.helpers import ocr
+
+    if items is None:
+        items = ocr(min_confidence=0.2)
+    texts = " ".join((it.get("text") or "") for it in items)
+    # Chinese Done/Edit and common OCR mangling of those buttons
+    markers = ("完成", "编辑", "Done", "Edit", "Remove", "移除")
+    if any(m in texts for m in markers):
+        # Avoid false positive on random in-app "Edit" alone — require
+        # springboard-ish combo or Chinese 完成 with other chrome.
+        if "完成" in texts or "编辑" in texts:
+            return True
+        if "Done" in texts and ("Edit" in texts or "Remove" in texts):
+            return True
+    return False
+
+
+def exit_home_edit_mode():
+    """Leave Home Screen jiggle/edit mode. NEVER tap red minus / delete.
+
+    Prefer 完成/Done; fall back to top-right tap then home().
+    """
+    from phone_harness.helpers import (
+        find_text,
+        home,
+        ocr,
+        screen_info,
+        screenshot,
+        tap,
+        wait,
+    )
+
+    items = ocr(min_confidence=0.2)
+    for label in ("完成", "Done"):
+        hits = find_text(label)
+        if hits:
+            tap(hits[0]["x"], hits[0]["y"])
+            wait(0.8)
+            return {"how": f"tap_text:{label}", "hit": hits[0]}
+
+    # Top-right Done region (common layout in jiggle mode)
+    w = screen_info()["window"]
+    tap(w["x"] + w["w"] * 0.88, w["y"] + w["h"] * 0.08)
+    wait(0.6)
+    home()
+    wait(0.8)
+    path = screenshot()
+    return {"how": "top_right_then_home", "screenshot": path}
+
+
+def paste_text(text: str):
+    """Paste arbitrary Unicode (incl. Chinese) into the focused iOS field.
+
+    Sets the Mac clipboard then sends cmd+v through the mirroring keyboard
+    path. Requires Continuity / paste into the mirrored field to work; always
+    verify with screenshot/ocr after calling. Briefly steals focus (keyboard).
+    """
+    from phone_harness.helpers import press
+
+    if text is None:
+        raise ValueError("paste_text requires text")
+    # pbcopy expects bytes on stdin
+    p = subprocess.run(
+        ["pbcopy"],
+        input=text.encode("utf-8"),
+        capture_output=True,
+    )
+    if p.returncode != 0:
+        raise RuntimeError(
+            f"pbcopy failed: {p.stderr.decode('utf-8', errors='replace')}"
+        )
+    time.sleep(0.15)
+    press("cmd+v")
+    time.sleep(0.35)
+    return True
+
+
+def open_app_latin(name: str):
+    """Open an app via Spotlight using ASCII/Latin only.
+
+    Same as open_app(), but fails fast if `name` is not typeable via keycodes
+    (e.g. Chinese). Use brand Latin names: dianping, meituan, wechat, …
+    """
+    from phone_harness.helpers import open_app
+    from phone_harness import mirror as mirror_mod
+
+    # Validate against US-layout keycodes before focusing Spotlight.
+    # Always use phone_harness.mirror (background module has no _keycode_for).
+    for ch in name:
+        if ch == "\n":
+            continue
+        code, _ = mirror_mod._keycode_for(ch)
+        if code is None:
+            raise ValueError(
+                f"open_app_latin cannot type {ch!r} in {name!r}; "
+                "use ASCII brand/pinyin (e.g. 'dianping') or screenshot+tap"
+            )
+    return open_app(name)
+
+
+def mirror_looks_live():
+    """Heuristic: screenshot is not a dead/black stream.
+
+    Returns dict with ok bool and stats. Does not replace viewing the image
+    for welcome screens — still screenshot+view after user says connected.
+    Pure black captures are typically tiny (~30KB); live UI is much larger.
+    """
+    import os
+
+    from phone_harness.helpers import screenshot
+
+    try:
+        path = screenshot()
+    except Exception as e:
+        return {"ok": False, "path": None, "bytes": 0, "reason": f"capture_failed:{e}"}
+
+    size = os.path.getsize(path) if path and os.path.exists(path) else 0
+    ok = size > 80000
+    return {
+        "ok": ok,
+        "path": path,
+        "bytes": size,
+        "reason": None if ok else "screenshot_too_small_likely_black_or_empty",
+    }

--- a/install.md
+++ b/install.md
@@ -89,5 +89,8 @@ Common cases:
   hasn't restarted since.
 - **Window not found**: the phone isn't paired, isn't in range, or iPhone
   Mirroring shows a connect screen — open the app manually once.
-- **Taps do nothing**: Accessibility missing, or another window stole focus —
-  events land only when the mirroring window is frontmost.
+- **Taps do nothing**: Accessibility missing. With the default **background**
+  backend (`PHONE_HARNESS_BACKGROUND=1`), the window does **not** need to be
+  frontmost — if you forced classic mode (`PHONE_HARNESS_BACKGROUND=0`),
+  events only land when iPhone Mirroring is frontmost. Also check the phone
+  session is `ready` (not "iPhone in Use").

--- a/phone-harness
+++ b/phone-harness
@@ -1,4 +1,7 @@
 #!/bin/sh
-# Dev launcher: run the working tree without installing.
+# Dev launcher: run the working tree. Prefer the project venv when present.
 DIR="$(cd "$(dirname "$0")" && pwd)"
+if [ -x "$DIR/.venv/bin/python" ]; then
+  PYTHONPATH="$DIR/src" exec "$DIR/.venv/bin/python" -m phone_harness.run "$@"
+fi
 PYTHONPATH="$DIR/src" exec python3 -m phone_harness.run "$@"

--- a/src/phone_harness/mirror.py
+++ b/src/phone_harness/mirror.py
@@ -22,17 +22,43 @@ TMP.mkdir(exist_ok=True)
 # --- window / app state ---
 
 def find_window():
-    """{x, y, w, h, id} of the mirroring window in screen points, or None."""
-    wins = Quartz.CGWindowListCopyWindowInfo(
-        Quartz.kCGWindowListOptionOnScreenOnly, Quartz.kCGNullWindowID) or []
-    for w in wins:
-        if w.get("kCGWindowOwnerName") == APP_NAME and w.get("kCGWindowLayer", 1) == 0:
-            b = w["kCGWindowBounds"]
-            if b["Width"] < 100:  # ignore panels/toolbars
+    """{x, y, w, h, id} of the mirroring window in screen points, or None.
+
+    Match by process (bundle id) rather than the English owner name — on
+    Chinese macOS the owner is "iPhone镜像", not "iPhone Mirroring".
+    """
+    app = running_app()
+    pids = {app.processIdentifier()} if app is not None else set()
+    # Localized owner names seen in the wild (English + Chinese).
+    owner_names = {APP_NAME, "iPhone镜像", "iPhone 镜像"}
+    def _pick(wins):
+        best = None
+        for w in wins:
+            owner = w.get("kCGWindowOwnerName") or ""
+            pid = w.get("kCGWindowOwnerPID")
+            if not ((pid in pids) or (owner in owner_names)):
                 continue
-            return {"x": b["X"], "y": b["Y"], "w": b["Width"], "h": b["Height"],
+            if w.get("kCGWindowLayer", 1) != 0:
+                continue
+            b = w["kCGWindowBounds"]
+            if b["Width"] < 100 or b["Height"] < 100:  # ignore panels/toolbars
+                continue
+            cand = {"x": b["X"], "y": b["Y"], "w": b["Width"], "h": b["Height"],
                     "id": int(w["kCGWindowNumber"])}
-    return None
+            # Prefer the largest window (the phone surface, not chrome).
+            if best is None or cand["w"] * cand["h"] > best["w"] * best["h"]:
+                best = cand
+        return best
+
+    onscreen = Quartz.CGWindowListCopyWindowInfo(
+        Quartz.kCGWindowListOptionOnScreenOnly, Quartz.kCGNullWindowID) or []
+    best = _pick(onscreen)
+    if best is not None:
+        return best
+    # Fallback: window exists but is on another Space / Stage Manager shelf.
+    all_wins = Quartz.CGWindowListCopyWindowInfo(
+        Quartz.kCGWindowListOptionAll, Quartz.kCGNullWindowID) or []
+    return _pick(all_wins)
 
 
 def running_app():


### PR DESCRIPTION
## Summary
- Expand `SKILL.md` with hard agent rules learned from real Chinese iOS sessions: never jiggle/delete Home Screen apps, `type_text` is ASCII-only, Chinese UI requires screenshot viewing (OCR is unreliable), `connection_state()==ready` is not enough without a live non-black stream, and stop at payment confirmation.
- Extend `agent-workspace/agent_helpers.py` with `exit_home_edit_mode`, `is_home_edit_mode`, `paste_text`, `open_app_latin`, and `mirror_looks_live`.
- Fix `find_window()` to match localized owner names (`iPhone镜像`) and prefer the largest phone surface.
- Small install note for background vs classic focus; dev launcher prefers project `.venv` when present.

## Test plan
- [ ] `phone-harness` loads new agent helpers (`exit_home_edit_mode`, `paste_text`, `open_app_latin`)
- [ ] `open_app_latin("大众点评")` raises a clear ValueError; `open_app_latin("dianping")` is keycode-valid
- [ ] On Chinese macOS, `find_window()` still finds the mirroring surface
- [ ] If Home Screen jiggle mode appears, `exit_home_edit_mode()` prefers 完成/Done and never taps red minus