### PR TITLE
scroll: end-detection never fires on a text-less list (_overlap of two empty sets)

### DIFF
--- a/src/phone_harness/helpers.py
+++ b/src/phone_harness/helpers.py
@@ -190,6 +190,8 @@ def _text_set(boxes):
 
 def _overlap(a, b):
     """Jaccard overlap of two text sets: ~1.0 = same screen, low = it moved."""
+    if not a and not b:
+        return 1.0      # a still screen with no readable text is the same screen
     if not a or not b:
         return 0.0
     return len(a & b) / len(a | b)


### PR DESCRIPTION
Fixes #24

## The bug

`_overlap()` returns `0.0` when **both** text sets are empty, so a screen with no
OCR-readable text in the content area reads as "it moved" on every single scroll —
`0.0` is far below `scroll_screen()`'s `moved_thresh` of `0.6`.

That contradicts the function's own docstring (`~1.0 = same screen`) and the module
invariant right above it (`helpers.py:170-175`):

> End-of-list is decided by whether the SCREEN MOVED, never by whether the caller's
> parser found new items. [...] only the pixels going still (after a settle window
> that lets lazy-loaded content arrive) means the end.

The consequence is that end-detection **never fires** on a text-less list. On a photo
grid, an icon grid or an image feed, `scroll_collect()` runs to `max_scrolls=400` and
`scroll_until()` to `max_scrolls=60`, each iteration paying the `settle=2.5s` window
plus the `0.8s` grace — instead of stopping after `end_after=3` still screens.

## The fix

```python
def _overlap(a, b):
    """Jaccard overlap of two text sets: ~1.0 = same screen, low = it moved."""
    if not a and not b:
        return 1.0      # a still screen with no readable text is the same screen
    if not a or not b:
        return 0.0
    return len(a & b) / len(a | b)
```

Two added lines, nothing else touched.

- **Both empty → `1.0`.** `Jaccard(∅, ∅) = 1` by definition, and "both captures found
  nothing" does mean the screen didn't change — which is exactly what the invariant
  asks `_overlap` to report.
- **One side empty → still `0.0`.** Deliberately unchanged: that is a real transition
  between a text screen and a text-less one, and there is no evidence the screen went
  still. The conservative answer keeps scrolling.
- **Non-empty sets → untouched.** The Jaccard arithmetic is not modified.

## Verification

The repo has no test directory and no test framework (no `pytest`/`unittest`/`tox`
anywhere, no `[project.optional-dependencies]`, no CI workflow), so rather than adding
a whole test harness for a two-line fix I'm attaching a self-contained check. It pulls
the **real** `_overlap` source out of `helpers.py` with `ast` and executes just that
function, so it runs without pyobjc installed. Happy to fold this into a real test
suite in whatever shape you'd want one, if you'd like tests here.

Save as `verify_overlap.py` and run from the repo root:

```python
import ast, pathlib, sys

SRC = pathlib.Path("src/phone_harness/helpers.py")
tree = ast.parse(SRC.read_text())
fn = next(n for n in tree.body
          if isinstance(n, ast.FunctionDef) and n.name == "_overlap")
ns = {}
exec(compile(ast.Module(body=[fn], type_ignores=[]), str(SRC), "exec"), ns)
_overlap = ns["_overlap"]

MOVED_THRESH = 0.6  # scroll_screen() default

cases = [
    (frozenset(), frozenset(), 1.0,
     "both empty = the same settled screen (issue #24)"),
    (frozenset({"Photos"}), frozenset(), 0.0,
     "one side empty = not comparable, stay conservative"),
    (frozenset(), frozenset({"Photos"}), 0.0,
     "one side empty = not comparable, stay conservative"),
    (frozenset({"a", "b"}), frozenset({"a", "b"}), 1.0,
     "identical non-empty sets = same screen"),
    (frozenset({"a", "b"}), frozenset({"b", "c"}), 1 / 3,
     "plain Jaccard, unchanged"),
    (frozenset({"a"}), frozenset({"b"}), 0.0,
     "disjoint non-empty sets = it moved"),
]

failures = []
for a, b, expected, why in cases:
    got = _overlap(a, b)
    ok = abs(got - expected) < 1e-9
    print(f"{'PASS' if ok else 'FAIL'}  _overlap({set(a) or 'empty'}, "
          f"{set(b) or 'empty'}) -> {got!r} (expected {expected!r}) - {why}")
    if not ok:
        failures.append((a, b, expected, got))

# The decision scroll_screen()/scroll_until()/scroll_collect() actually make.
moved = _overlap(frozenset(), frozenset()) < MOVED_THRESH
print(f"{'PASS' if not moved else 'FAIL'}  scroll_screen() on a still, text-less "
      f"screen -> moved={moved} (expected False)")
if moved:
    failures.append(("moved", "empty/empty", False, True))

print(f"\n{len(cases) + 1 - len(failures)}/{len(cases) + 1} passed")
sys.exit(1 if failures else 0)
```

**Before the fix** (`git stash` the change, or run on `4d2de7a`):

```
$ python3 verify_overlap.py
FAIL  _overlap(empty, empty) -> 0.0 (expected 1.0) - both empty = the same settled screen (issue #24)
PASS  _overlap({'Photos'}, empty) -> 0.0 (expected 0.0) - one side empty = not comparable, stay conservative
PASS  _overlap(empty, {'Photos'}) -> 0.0 (expected 0.0) - one side empty = not comparable, stay conservative
PASS  _overlap({'a', 'b'}, {'a', 'b'}) -> 1.0 (expected 1.0) - identical non-empty sets = same screen
PASS  _overlap({'a', 'b'}, {'b', 'c'}) -> 0.3333333333333333 (expected 0.3333333333333333) - plain Jaccard, unchanged
PASS  _overlap({'a'}, {'b'}) -> 0.0 (expected 0.0) - disjoint non-empty sets = it moved
FAIL  scroll_screen() on a still, text-less screen -> moved=True (expected False)

5/7 passed
$ echo $?
1
```

**After the fix** (this branch):

```
$ python3 verify_overlap.py
PASS  _overlap(empty, empty) -> 1.0 (expected 1.0) - both empty = the same settled screen (issue #24)
PASS  _overlap({'Photos'}, empty) -> 0.0 (expected 0.0) - one side empty = not comparable, stay conservative
PASS  _overlap(empty, {'Photos'}) -> 0.0 (expected 0.0) - one side empty = not comparable, stay conservative
PASS  _overlap({'a', 'b'}, {'a', 'b'}) -> 1.0 (expected 1.0) - identical non-empty sets = same screen
PASS  _overlap({'a', 'b'}, {'b', 'c'}) -> 0.3333333333333333 (expected 0.3333333333333333) - plain Jaccard, unchanged
PASS  _overlap({'a'}, {'b'}) -> 0.0 (expected 0.0) - disjoint non-empty sets = it moved
PASS  scroll_screen() on a still, text-less screen -> moved=False (expected False)

7/7 passed
$ echo $?
0
```

Also ran `python3 -m compileall -q src/phone_harness agent-workspace` — clean.

### What I could not run

There is no existing test suite to run, so "no regressions" rests on the checks above
plus a call-site audit: `_overlap` has exactly two callers, both inside
`scroll_screen()` (`helpers.py:232-233`), and neither relies on the old empty/empty
result. I also could **not** exercise this end-to-end against a real phone — that needs
iPhone Mirroring paired with hardware plus Accessibility and Screen Recording
permissions, which I don't have on this machine. The reasoning path from `_overlap` to
`moved` to the `stale`/`end_after` counters is pure Python and is what the script
above covers.

---

*Disclosure: this change was prepared with AI assistance. I reproduced the bug locally,
verified the fix myself, and reviewed every line before opening this PR.*
