### PR TITLE
fix: window discovery on localized macOS, and Vision options on pyobjc 12

### DIFF
--- a/src/phone_harness/mirror.py
+++ b/src/phone_harness/mirror.py
@@ -25,8 +25,14 @@ def find_window():
     """{x, y, w, h, id} of the mirroring window in screen points, or None."""
     wins = Quartz.CGWindowListCopyWindowInfo(
         Quartz.kCGWindowListOptionOnScreenOnly, Quartz.kCGNullWindowID) or []
+    # Match on pid, not owner name: the app name is localized (e.g. "iPhone
+    # 미러링" on a Korean system) and never matches the English constant.
+    app = running_app()
+    pid = app.processIdentifier() if app is not None else None
     for w in wins:
-        if w.get("kCGWindowOwnerName") == APP_NAME and w.get("kCGWindowLayer", 1) == 0:
+        owned = (w.get("kCGWindowOwnerPID") == pid if pid is not None
+                 else w.get("kCGWindowOwnerName") == APP_NAME)
+        if owned and w.get("kCGWindowLayer", 1) == 0:
             b = w["kCGWindowBounds"]
             if b["Width"] < 100:  # ignore panels/toolbars
                 continue

--- a/src/phone_harness/ocr.py
+++ b/src/phone_harness/ocr.py
@@ -23,8 +23,10 @@ def recognize(path, window):
     screen points — pass straight to tap(). Vision's normalized boxes have a
     bottom-left origin; screen points have a top-left origin, hence the flip.
     """
+    # pyobjc 12.x rejects an empty options dict here ("key does not exist");
+    # None is the correct way to pass no options.
     handler = Vision.VNImageRequestHandler.alloc().initWithURL_options_(
-        NSURL.fileURLWithPath_(path), {})
+        NSURL.fileURLWithPath_(path), None)
     request = Vision.VNRecognizeTextRequest.alloc().init()
     request.setRecognitionLevel_(Vision.VNRequestTextRecognitionLevelAccurate)
     ok, err = handler.performRequests_error_([request], None)


### PR DESCRIPTION
## What

Two independent fixes that both block a clean install. `--doctor` fails at a different rung of the ladder for each.

### 1. Window discovery fails on a localized macOS

`find_window()` compares `kCGWindowOwnerName` to the English constant `"iPhone Mirroring"`. macOS localizes the app name — on a Korean system it is `"iPhone 미러링"` — so the comparison never matches. `--doctor` reports `[FAIL] mirroring window found` while the window is plainly on screen and every other check passes, which sends you chasing a pairing problem that isn't there.

Fixed by resolving the app through its bundle id and matching windows on `kCGWindowOwnerPID`, which is locale-independent. The name comparison stays as a fallback when the app isn't running, so the `None` return path is unchanged.

### 2. Vision OCR raises on pyobjc 12.x

```
VNImageRequestHandler.alloc().initWithURL_options_(url, {})
ValueError: NSInvalidArgumentException - key does not exist
```

An empty options dict is rejected; `None` is the correct "no options" form. Without this, OCR fails on every call once the window is found.

## Testing

macOS 26.0 (arm64), Python 3.14.6, pyobjc 12.2.2, real paired iPhone.

Before: `--doctor` stopped at the window check.
After: all eight checks PASS, `screen_info()` returns window bounds, `ocr()` returns text boxes from the phone screen.

## Note — not included in this PR

`pyproject.toml` lists `pyobjc-framework-AppKit`, but no such package exists on PyPI; `AppKit` ships inside `pyobjc-framework-Cocoa`. `install.md`'s pip line has the same name. A plain `pip install -e .` fails on it — I worked around it locally by installing `pyobjc-framework-Cocoa`. Left out to keep this PR to the two runtime bugs, but happy to fold it in if you'd like.
