### PR TITLE
pyproject: depend on pyobjc-framework-Cocoa, not the nonexistent -AppKit

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ requires-python = ">=3.10"
 dependencies = [
     "pyobjc-framework-Quartz",
     "pyobjc-framework-Vision",
-    "pyobjc-framework-AppKit",
+    "pyobjc-framework-Cocoa",
     "pyobjc-framework-ApplicationServices",
 ]
 


### PR DESCRIPTION
\`pip install .\` currently fails dependency resolution: **\`pyobjc-framework-AppKit\` is not a package on PyPI** — the AppKit bindings ship inside \`pyobjc-framework-Cocoa\`. This swaps the dependency so a fresh install works out of the box.

Verified by rebuilding a clean venv with the updated dependency list; \`import AppKit\` and the doctor's framework check both pass with only \`pyobjc-framework-Cocoa\` installed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)