### PR TITLE
mirror: find the window by PID — kCGWindowOwnerName is localized

### DIFF
--- a/src/phone_harness/mirror.py
+++ b/src/phone_harness/mirror.py
@@ -23,10 +23,16 @@ TMP.mkdir(exist_ok=True)
 
 def find_window():
     """{x, y, w, h, id} of the mirroring window in screen points, or None."""
+    # kCGWindowOwnerName is localized ("iPhone 미러링" on a Korean Mac), so
+    # match by the running app's PID and fall back to the English name.
+    app = running_app()
+    pid = app.processIdentifier() if app else None
     wins = Quartz.CGWindowListCopyWindowInfo(
         Quartz.kCGWindowListOptionOnScreenOnly, Quartz.kCGNullWindowID) or []
     for w in wins:
-        if w.get("kCGWindowOwnerName") == APP_NAME and w.get("kCGWindowLayer", 1) == 0:
+        owned = (w.get("kCGWindowOwnerPID") == pid if pid is not None
+                 else w.get("kCGWindowOwnerName") == APP_NAME)
+        if owned and w.get("kCGWindowLayer", 1) == 0:
             b = w["kCGWindowBounds"]
             if b["Width"] < 100:  # ignore panels/toolbars
                 continue


### PR DESCRIPTION
On a non-English macOS the mirroring window's \`kCGWindowOwnerName\` is localized — on a Korean system it is \`"iPhone 미러링"\` — so the English string compare in \`find_window()\` never matches and the harness reports "no phone window" even though the app is running and connected.

This matches by the running app's PID (\`kCGWindowOwnerPID\`) instead, which is locale-independent, and keeps the English name compare as a fallback when the app lookup fails.

Verified on a Korean-locale Mac (Sequoia): before the change \`find_window()\` returns \`None\`; after, the full capture → OCR → tap loop works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)