### PR TITLE
doctor: report a FAIL instead of crashing when capture fails

### DIFF
--- a/src/phone_harness/admin.py
+++ b/src/phone_harness/admin.py
@@ -48,19 +48,21 @@ def run_doctor():
         with tempfile.NamedTemporaryFile(suffix=".png", delete=False) as f:
             path = f.name
         try:
-            subprocess.run(
+            r = subprocess.run(
                 ["screencapture", "-x", "-o", "-l", str(win["id"]), path],
-                check=True)
-            size = os.path.getsize(path)
-            ok &= _check(f"window capture works ({size} bytes)", size > 20_000,
-                         "capture is blank — Screen Recording permission "
+                capture_output=True)
+            size = os.path.getsize(path) if os.path.exists(path) else 0
+            ok &= _check(f"window capture works ({size} bytes)",
+                         r.returncode == 0 and size > 20_000,
+                         "capture failed/blank — Screen Recording permission "
                          "needs a terminal restart to take effect")
-            if size > 20_000:
+            if r.returncode == 0 and size > 20_000:
                 from . import ocr
                 n = len(ocr.recognize(path, win))
                 _check(f"Vision OCR works ({n} text boxes)", True)
         finally:
-            os.unlink(path)
+            if os.path.exists(path):
+                os.unlink(path)
 
     print("\nall clear" if ok else "\nfix the FAILs above, then re-run")
     print("\nnote: these are the permissions currently known to be required. A "


### PR DESCRIPTION
When Screen Recording permission is missing — the exact situation \`--doctor\` exists to diagnose — \`screencapture\` exits non-zero, so \`check=True\` raises \`CalledProcessError\` and doctor dies with a traceback before printing its verdict (and \`os.path.getsize\` can raise too, since no file was written).

This captures the subprocess result, reports the failure as a normal \`[FAIL]\` line with the existing restart-your-terminal hint, and guards the tempfile cleanup for the no-file case. Doctor now always runs to completion.

Repro: revoke Screen Recording for your terminal and run \`phone-harness --doctor\` — before: traceback; after: \`[FAIL] window capture works (0 bytes)\` and the summary line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)