### PR TITLE
deps: pyobjc-framework-AppKit doesn't exist on PyPI, use pyobjc-framework-Cocoa

### DIFF
--- a/install.md
+++ b/install.md
@@ -7,7 +7,8 @@ Use once. For phone work, read `SKILL.md`.
 - macOS Sequoia+ with iPhone Mirroring paired to the phone (open the app once
   manually to pair — pairing prompts need the physical phone).
 - Python 3.12+ with pyobjc (`pip install pyobjc-framework-Quartz
-  pyobjc-framework-Vision pyobjc-framework-AppKit`).
+  pyobjc-framework-Vision pyobjc-framework-Cocoa`). `AppKit` lives in
+  `pyobjc-framework-Cocoa` — there is no `pyobjc-framework-AppKit` on PyPI.
 - The terminal app needs two permissions in System Settings > Privacy &
   Security. **The toggles require the user:**
   - **Accessibility** — taps and keystrokes. Takes effect immediately.
@@ -36,7 +37,7 @@ open "x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenCapt
 ```bash
 git clone https://github.com/ShawnPana/phone-harness ~/.phone-harness   # canonical home
 cd ~/.phone-harness
-pip install pyobjc-framework-Quartz pyobjc-framework-Vision pyobjc-framework-AppKit
+pip install pyobjc-framework-Quartz pyobjc-framework-Vision pyobjc-framework-Cocoa
 pip install -e . --no-deps            # installs the global `phone-harness` command
 
 # register as an agent skill so Claude Code / Codex auto-use it (see below)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ requires-python = ">=3.10"
 dependencies = [
     "pyobjc-framework-Quartz",
     "pyobjc-framework-Vision",
-    "pyobjc-framework-AppKit",
+    "pyobjc-framework-Cocoa",
     "pyobjc-framework-ApplicationServices",
 ]
 


### PR DESCRIPTION
Following `install.md` on a clean machine fails before the first check runs:

```
ERROR: Could not find a version that satisfies the requirement
pyobjc-framework-AppKit (from versions: none)
ERROR: No matching distribution found for pyobjc-framework-AppKit
```

There is no `pyobjc-framework-AppKit` package published on PyPI. The `AppKit` module that `admin.py` imports actually ships inside **`pyobjc-framework-Cocoa`**, so the dependency as written can never be installed.

This is easy to miss, because `pyobjc-framework-Quartz` already depends on `pyobjc-framework-Cocoa` under the hood. Any machine that installed Quartz at some point therefore has a working `import AppKit` anyway. The problem only shows up when pip is asked to look up the name `pyobjc-framework-AppKit` itself, which is exactly what `pip install -e .` does.

This PR swaps the name in `pyproject.toml` and in both places `install.md` mentions it.

**Verified** in a fresh throwaway venv (Python 3.14, macOS 26):

- `pip install -e .` resolves and builds, with no need for `--no-deps`
- `import Quartz, Vision, AppKit, ApplicationServices` all succeed
- the installed `phone-harness --doctor` command runs
