### PR TITLE
doctor: "all clear" and exit 0 while the mirroring window check is FAILing

### DIFF
--- a/src/phone_harness/admin.py
+++ b/src/phone_harness/admin.py
@@ -41,8 +41,8 @@ def run_doctor():
            "will auto-launch on first use — not fatal")
 
     win = mirror.find_window()
-    _check("mirroring window found", win is not None,
-           "open iPhone Mirroring once manually to pair the phone")
+    ok &= _check("mirroring window found", win is not None,
+                 "open iPhone Mirroring once manually to pair the phone")
 
     if win:
         with tempfile.NamedTemporaryFile(suffix=".png", delete=False) as f:


### PR DESCRIPTION
`--doctor` runs eight checks and keeps one variable, `ok`, to remember whether everything passed. Each check is supposed to set `ok` to false when it fails. The `"mirroring window found"` check never does, so its failure is discarded.

The output ends up contradicting itself. With iPhone Mirroring open but no phone connected:

```
  [PASS] pyobjc frameworks (Quartz, Vision, AppKit)
  [PASS] Accessibility permission (taps & keystrokes)
  [PASS] Screen Recording permission (seeing the phone)
  [PASS] iPhone Mirroring installed
  [FAIL] iPhone Mirroring running — will auto-launch on first use — not fatal
  [FAIL] mirroring window found — open iPhone Mirroring once manually to pair the phone

all clear
$ echo $?
0
```

An exit status of 0 means success to anything reading it. So a setup script, or an agent using `--doctor` to ask "is the phone ready?", is told yes and then goes on to tap and type at a phone that isn't connected.

There's a second effect. The last two checks, window capture and OCR, only run when a window was found (`if win`), so a missing window skips them silently. `all clear` gets printed after running six of the eight checks, and one of those six failed.

I ran into this while setting the project up and believed the harness was ready when it wasn't.

The check directly above, `"iPhone Mirroring running"`, also leaves `ok` alone, but that one is clearly intentional and says so in its own output: `"will auto-launch on first use — not fatal"`. A missing window isn't recoverable that way, and both `README.md` and `install.md` describe the sequence as something where you `Fix the first FAIL`. Happy to close this if the omission was deliberate.

**Verified** both directions:

- With `find_window()` stubbed to return `None`, the summary becomes `fix the FAILs above, then re-run` and the exit status is `1`.
- Against a real connected iPhone, all eight checks still pass, it still prints `all clear`, and the exit status is still `0`.
