### PR TITLE
SKILL.md: document background-mode delivery and the raw-event focus trap

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -27,8 +27,11 @@ PY
 
 - Invoke as `phone-harness`. Use heredocs for multi-line commands.
 - Helpers are pre-imported. All coordinates are global screen points.
-- `ensure_mirroring()` launches and focuses the window; input helpers focus it
-  automatically before posting events.
+- `ensure_mirroring()` launches the window and gates on connection. The
+  default build then works the phone **without focusing it**: capture is by
+  window id and input is an event record delivered straight to the app, so a
+  task never steals the user's screen. `PHONE_HARNESS_BACKGROUND=0` forces the
+  classic path, which must focus before every action.
 
 ## Screen Workflow
 
@@ -53,10 +56,14 @@ PY
   new rows — a dense screen or a missed OCR line will not end the scroll
   early. Each step settles first so lazy-loaded content arrives before the
   movement check. `scroll_screen()` is the single-step primitive if you need
-  it. These use wheel scrolling (a slow touch-drag barely moves an iOS list
-  and bounces back).
+  it. In the background build these scroll with momentum flicks — wheel
+  events only route to a *focused* window, and a slow touch-drag barely moves
+  an iOS list before bouncing back; only a fast flick carries it.
 - Raw Quartz is the escape hatch: `import Quartz` in your script for anything
-  the helpers don't cover.
+  the helpers don't cover — but raw CGEvents don't ride the helpers' delivery
+  path. They land only while the window is frontmost and are swallowed
+  silently otherwise, scroll-wheel events included: `activate()` first, then
+  verify the screen actually changed.
 
 ## Consent
 
@@ -83,8 +90,13 @@ raises a clear message (call `connection_state()` yourself to check —
 
 ## Gotchas
 
-- **Unfocused input is swallowed silently.** The window must be frontmost;
-  helpers call `activate()` but if a click steals focus mid-task, re-activate.
+- **Unfocused input is swallowed silently — for events you post yourself.**
+  The helpers are immune in the background build (input goes straight to the
+  app), but raw CGEvents and the `PHONE_HARNESS_BACKGROUND=0` path need the
+  window frontmost: `activate()` before posting, and re-activate if a click
+  steals focus mid-task. The failure looks exactly like "scrolling is broken"
+  or "the list already ended" — when a gesture changes nothing on screen,
+  check focus before inventing another theory.
 - **The window is a video stream.** macOS accessibility sees nothing inside
   it; AppleScript `click at` fails silently. Only HID-level CGEvents work.
 - **The window moves.** Never cache coordinates across calls; `ocr()` and


### PR DESCRIPTION
The skill's delivery model was three builds out of date. It still said helpers focus the window before posting events, that the scroll helpers "use wheel scrolling", and offered raw Quartz as an escape hatch with no caveat. All three predate bac4785 (`background: scroll via momentum flicks`), which exists precisely because wheel events don't route to an unfocused window — the knowledge landed in a docstring and never made it up to the skill.

## What it cost

Measured in a live session driving X's notifications list: helper flicks looked flaky on a dense list, the agent dropped to raw wheel events, those landed in an unfocused window and were swallowed silently. The symptom is indistinguishable from "the list ended" — the agent burned ~10 minutes on app-restart theories (restarting "worked" only because relaunch grants focus) before the user diagnosed it from the outside: the window wasn't focused. One `activate()` call fixed it permanently.

## Changes

- **Usage**: `ensure_mirroring()` bullet now describes the background build honestly — capture by window id, input posted straight to the app, nothing focused, `PHONE_HARNESS_BACKGROUND=0` for the classic focused path.
- **Scrolling**: "these use wheel scrolling" → momentum flicks, with the why (wheel needs focus; slow drags bounce back; velocity carries the list).
- **Raw Quartz escape hatch**: now warns that raw CGEvents don't ride the helpers' delivery path — frontmost or silently swallowed, wheel events included; `activate()` first, verify movement after.
- **Gotchas**: "Unfocused input is swallowed silently" rewritten to say *whose* input — helpers are immune in the background build, raw events and the classic path are not — and names the misleading symptom so the next agent checks focus before inventing theories.

Docs only. Targets main directly because both the stale text and the flick implementation are already on main; no overlap with the SKILL.md hunks in #18/#20 (consent section, type_text bullets), so the stack rebases clean over this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)