### PR TITLE
fix: work outside English locales (PyPI dep name, window matching, OCR language)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ requires-python = ">=3.10"
 dependencies = [
     "pyobjc-framework-Quartz",
     "pyobjc-framework-Vision",
-    "pyobjc-framework-AppKit",
+    "pyobjc-framework-Cocoa",
     "pyobjc-framework-ApplicationServices",
 ]
 

--- a/src/phone_harness/mirror.py
+++ b/src/phone_harness/mirror.py
@@ -22,11 +22,21 @@ TMP.mkdir(exist_ok=True)
 # --- window / app state ---
 
 def find_window():
-    """{x, y, w, h, id} of the mirroring window in screen points, or None."""
+    """{x, y, w, h, id} of the mirroring window in screen points, or None.
+
+    Windows are matched by the owner PID of the running app (bundle id), not
+    by kCGWindowOwnerName: the owner name is the app's *localized* display
+    name (e.g. "iPhone鏡像輸出" on a zh_TW system), so a name match finds
+    nothing outside English locales.
+    """
+    app = running_app()
+    if app is None:
+        return None
+    pid = int(app.processIdentifier())
     wins = Quartz.CGWindowListCopyWindowInfo(
         Quartz.kCGWindowListOptionOnScreenOnly, Quartz.kCGNullWindowID) or []
     for w in wins:
-        if w.get("kCGWindowOwnerName") == APP_NAME and w.get("kCGWindowLayer", 1) == 0:
+        if w.get("kCGWindowOwnerPID") == pid and w.get("kCGWindowLayer", 1) == 0:
             b = w["kCGWindowBounds"]
             if b["Width"] < 100:  # ignore panels/toolbars
                 continue

--- a/src/phone_harness/ocr.py
+++ b/src/phone_harness/ocr.py
@@ -27,6 +27,12 @@ def recognize(path, window):
         NSURL.fileURLWithPath_(path), {})
     request = Vision.VNRecognizeTextRequest.alloc().init()
     request.setRecognitionLevel_(Vision.VNRequestTextRecognitionLevelAccurate)
+    # Vision defaults to Latin-script recognition, so a phone running in a
+    # CJK (or any non-Latin) locale OCRs to garbage. Let Vision detect the
+    # language itself where supported (macOS 13+; iPhone Mirroring itself
+    # needs macOS 15+, the guard just keeps older hosts harmless).
+    if request.respondsToSelector_("setAutomaticallyDetectsLanguage:"):
+        request.setAutomaticallyDetectsLanguage_(True)
     ok, err = handler.performRequests_error_([request], None)
     if not ok:
         raise RuntimeError(f"Vision OCR failed: {err}")


### PR DESCRIPTION
Three independent fixes found while driving phone-harness for real on a zh_TW (Traditional Chinese) macOS 26 host with a paired iPhone. Each was verified live against a connected iPhone Mirroring session; together they take the project from "cannot even pip-resolve" to a working capture → OCR → tap cycle on a non-English system.

## 1. `pyobjc-framework-AppKit` does not exist on PyPI

`pyproject.toml` declares `pyobjc-framework-AppKit`, but PyPI has never published a package under that name — its simple index returns 404, so `pip install` of the project fails outright with "No matching distribution found". The AppKit bindings ship inside `pyobjc-framework-Cocoa`. One-line dependency swap; `pip install --dry-run --report` resolves the full graph cleanly afterwards (pyobjc 12.2.2 across the family on CPython 3.14/macOS arm64).

## 2. Window discovery matches the *localized* app name

`mirror.find_window()` matches `kCGWindowOwnerName == "iPhone Mirroring"`, but `kCGWindowOwnerName` carries the app's localized display name — on a zh_TW system the owner is `iPhone鏡像輸出`, so `find_window()` returns `None` on every non-English macOS even with a connected mirroring window on screen. Since `running_app()` already resolves the app by bundle id (`com.apple.ScreenContinuity`), the window is now matched by `kCGWindowOwnerPID` instead. Verified live: the same window that name-matching missed is found immediately (with the existing size filter intact).

## 3. Vision OCR runs Latin-only by default

`VNRecognizeTextRequest` with no recognition languages configured performs Latin-script recognition, so any phone running in a CJK (or other non-Latin) locale OCRs to garbage — a zh_TW Settings screen read back as `'Apple ESA-iflad#'` / `'‡#ñApp¡*·#'`, which breaks the OCR-as-element-tree model completely (no tap target can ever match). Enabling `automaticallyDetectsLanguage` (macOS 13+, behind a `respondsToSelector` guard so older hosts are unaffected; iPhone Mirroring itself needs macOS 15+) makes the same screen read back as correct Traditional Chinese at 1.00 confidence:

```
before:  0.3  'Apple ESA-iflad#'      after:  1.00  '請鎖定iPhone來連接。'
         0.3  '‡#ñApp¡*·#'                    1.00  '連線'
```

No behavior change on English-locale systems for any of the three; fixes 2 and 3 only remove the implicit English-locale assumption.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
