### PR TITLE
doctor: activate iPhone Mirroring before looking for its window

### DIFF
--- a/src/phone_harness/admin.py
+++ b/src/phone_harness/admin.py
@@ -63,6 +63,13 @@ def _doctor_ios():
     _check(f"{mirror.APP_NAME} running", running,
            "will auto-launch on first use — not fatal", fatal=False)
 
+    # Activate first — the mirroring window is only listed on-screen
+    # while the app is frontmost, so a background app reads as "no window".
+    if running:
+        try:
+            mirror.activate()
+        except RuntimeError:
+            pass
     win = mirror.find_window()
     _check("mirroring window found", win is not None,
            "open iPhone Mirroring once manually to pair the phone")


### PR DESCRIPTION
Rebased onto current main. Of the original four fixes, three are no longer needed here:

- pyproject (`pyobjc-framework-Cocoa`), `find_window()` PID matching, and real modifier key events have all since landed on main.
- The OCR recognition-language fix is superseded by #47, which combines it with #37's auto-detection.

What remains is one fix: doctor now activates iPhone Mirroring before looking for its window. macOS lists the mirroring window on-screen only while the app is frontmost, so a backgrounded app read as "no window" even with a connected phone, and doctor reported a false FAIL.

Verified on a paired iPhone: doctor all-PASS with the app previously backgrounded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)