### PR TITLE
Drive an Android phone through connect("android")

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -60,10 +60,11 @@ PY
 
 ## Android
 
-Same helpers, different phone: prefix every invocation with
-`PHONE_HARNESS_PLATFORM=android` (or export it once). The harness finds the
-phone itself — a USB phone if plugged in, else the paired Wi-Fi phone — so
-there is nothing to select.
+Same helpers, different phone. `phone-harness use android` makes Android the
+default (`phone-harness use` shows the current one); until then, or to
+override per call, prefix with `PHONE_HARNESS_PLATFORM=android`. The harness
+finds the phone itself — a USB phone if plugged in, else the paired Wi-Fi
+phone — so there is nothing to select.
 
 ```bash
 PHONE_HARNESS_PLATFORM=android phone-harness <<'PY'

--- a/SKILL.md
+++ b/SKILL.md
@@ -83,6 +83,17 @@ PY
   raise Unsupported. `type_text` needs a focused field, same as iOS.
 - No focus to keep: nothing on the Mac has to be frontmost, and `interruption`
   is always nothing.
+- **Verify cheaply, then read.** adb reports nothing about outcomes — a tap on
+  empty space "succeeds". After an action: `wait_for_app("com.android.chrome")`
+  (~0.1s per poll) or `wait_for_text("Got it")` (returns the box or None),
+  then `ui()`/`ocr()` once for contents. The tree costs ~2-3s a call on a slow
+  phone and a screenshot ~0.5s, so batch a whole sub-task in one invocation
+  and filter in Python rather than one call per turn.
+- **The phone locks itself** after its screen timeout. `connection_state()`
+  reports `locked`; taps and `ocr()` refuse with the same message. Ask the
+  user to unlock — never type a PIN. `screenshot()` still works locked, so you
+  can show them what you see. Developer options > Stay awake keeps it on
+  while charging (ask before changing it).
 - Connection is still the user's job (USB debugging + Allow, or Wireless
   debugging + `phone-harness android pair IP:PORT CODE`); on `no-device` the
   error names the missing step — relay it, don't retry-loop.

--- a/SKILL.md
+++ b/SKILL.md
@@ -98,7 +98,7 @@ PY
   changing any phone setting; `phone-harness android rest` ends it and lets
   the phone sleep. Do that at the end of the task.
 - Connection is still the user's job (USB debugging + Allow, or Wireless
-  debugging + `phone-harness android pair IP:PORT CODE`); on `no-device` the
+  debugging + `phone-harness android pair CODE`); on `no-device` the
   error names the missing step — relay it, don't retry-loop.
   `phone-harness android` shows known phones and what is attached.
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -92,8 +92,11 @@ PY
 - **The phone locks itself** after its screen timeout. `connection_state()`
   reports `locked`; taps and `ocr()` refuse with the same message. Ask the
   user to unlock — never type a PIN. `screenshot()` still works locked, so you
-  can show them what you see. Developer options > Stay awake keeps it on
-  while charging (ask before changing it).
+  can show them what you see. For a task longer than a minute, ask the user,
+  then run `phone-harness android awake --bg`: it keeps the phone awake for
+  the session (and opens a mirror window if scrcpy is installed) without
+  changing any phone setting; `phone-harness android rest` ends it and lets
+  the phone sleep. Do that at the end of the task.
 - Connection is still the user's job (USB debugging + Allow, or Wireless
   debugging + `phone-harness android pair IP:PORT CODE`); on `no-device` the
   error names the missing step — relay it, don't retry-loop.

--- a/SKILL.md
+++ b/SKILL.md
@@ -60,9 +60,10 @@ PY
 
 ## Android
 
-Same helpers, different phone. `phone-harness use android` makes Android the
-default (`phone-harness use` shows the current one); until then, or to
-override per call, prefix with `PHONE_HARNESS_PLATFORM=android`. The harness
+Same helpers, different phone. `phone-harness config set platform android`
+makes Android the default (`phone-harness config` shows every setting and
+where it came from); until then, or to override per call, prefix with
+`PHONE_HARNESS_PLATFORM=android`. The harness
 finds the phone itself — a USB phone if plugged in, else the paired Wi-Fi
 phone — so there is nothing to select.
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: phone-harness
-description: "Control the user's iPhone through the Mac's iPhone Mirroring window: open apps, tap, type, swipe, read the screen."
+description: "Control the user's phone — iPhone through the Mac's iPhone Mirroring window, or an Android over adb: open apps, tap, type, swipe, read the screen."
 ---
 
 # phone-harness
@@ -57,6 +57,36 @@ PY
   and bounces back).
 - Raw Quartz is the escape hatch: `import Quartz` in your script for anything
   the helpers don't cover.
+
+## Android
+
+Same helpers, different phone: prefix every invocation with
+`PHONE_HARNESS_PLATFORM=android` (or export it once). The harness finds the
+phone itself — a USB phone if plugged in, else the paired Wi-Fi phone — so
+there is nothing to select.
+
+```bash
+PHONE_HARNESS_PLATFORM=android phone-harness <<'PY'
+open_app("chrome"); wait_stable()
+tap_ui("Got it")                    # exact label from the accessibility tree
+PY
+```
+
+- Coordinates are device pixels; the screenshot is 1:1 with `tap(x, y)`.
+- `ocr()` is the accessibility tree (`source: "tree"`) — exact, no misreads.
+  Prefer `ui()` / `find_nodes()` / `tap_ui()`: they also see elements with no
+  visible text (icons with a content-description, fields by resource-id like
+  `tap_ui("url_bar")`). `ocr_pixels()` is Unsupported here.
+- `back()`, `current_app()`, `list_apps()` exist. `open_app("chrome")`
+  matches installed package ids and returns the one launched.
+- `press()` takes single keys only (`"enter"`, `"back"`, `"tab"`); chords
+  raise Unsupported. `type_text` needs a focused field, same as iOS.
+- No focus to keep: nothing on the Mac has to be frontmost, and `interruption`
+  is always nothing.
+- Connection is still the user's job (USB debugging + Allow, or Wireless
+  debugging + `phone-harness android pair IP:PORT CODE`); on `no-device` the
+  error names the missing step — relay it, don't retry-loop.
+  `phone-harness android` shows known phones and what is attached.
 
 ## Consent
 

--- a/src/phone_harness/android.py
+++ b/src/phone_harness/android.py
@@ -28,7 +28,10 @@ import json
 import os
 import re
 import shlex
+import shutil
+import signal
 import subprocess
+import sys
 import tempfile
 import time
 import xml.etree.ElementTree as ET
@@ -230,8 +233,8 @@ class Android(Backend):
             raise RuntimeError(
                 "The Android phone is locked. Unlock it (PIN / fingerprint), "
                 "then retry — I won't enter a PIN. It re-locks after its screen "
-                "timeout; Settings > Developer options > Stay awake keeps it on "
-                "while charging.")
+                "timeout; `phone-harness android awake` keeps it awake for the "
+                "session without changing any setting.")
         self._gate_at = time.time()
 
     # --- screen -------------------------------------------------------------
@@ -510,7 +513,108 @@ CLI_USAGE = """Usage:
   phone-harness android connect [NAME|IP:PORT]   connect a paired phone (default: primary, via mDNS)
   phone-harness android use NAME                 make NAME the primary
   phone-harness android forget NAME
+  phone-harness android awake [--bg] [--no-mirror]
+        keep the phone awake for a session (and mirror it if scrcpy is
+        installed); changes no phone settings — ends with rest, Ctrl-C, or
+        closing the mirror. --bg detaches.
+  phone-harness android rest                     end the session; the phone sleeps
 """
+
+PIDFILE = CONFIG.with_name("awake.pid")
+POKE_EVERY = 25          # seconds; a phone's shortest screen timeout is 15s
+POKE = "input keyevent KEYCODE_UNKNOWN"   # counts as user activity; no app sees it
+
+
+def _phone_label(adb_id):
+    """The registry name for the phone behind adb_id, else its model."""
+    try:
+        serial = _prop(adb_id, "ro.serialno")
+        for name, p in (_load().get("phones") or {}).items():
+            if p.get("serial") == serial:
+                return name
+        return _prop(adb_id, "ro.product.model") or adb_id
+    except RuntimeError:
+        return adb_id
+
+
+def _awake(mirror=True):
+    """The session companion. Wakes the phone; waits for the user to unlock
+    if it is locked; then every POKE_EVERY seconds sends a keypress no app
+    reacts to, which the phone counts as user activity — so it never
+    reaches its screen timeout while this runs, on USB or Wi-Fi, charging
+    or not, and reverts to normal the instant this stops. No setting is
+    written. Pokes pause while the phone is locked (a lock screen should be
+    allowed to go dark). If scrcpy is installed, mirrors the same phone in
+    a window titled with its name; closing that window ends the session."""
+    phone = Android()
+    adb_id = phone._resolve()
+    if adb_id is None:
+        phone._session_require()               # raises with the physical step
+    label = _phone_label(adb_id)
+    print(f"awake: {label} ({adb_id})", flush=True)
+    proc = None
+    if mirror and shutil.which("scrcpy"):
+        proc = subprocess.Popen(
+            ["scrcpy", "-s", adb_id, "--stay-awake", "--no-audio",
+             "--always-on-top", "--window-title", f"phone-harness: {label}",
+             "--window-width", "360"],
+            stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        print("mirror: scrcpy window open (close it to end)", flush=True)
+    elif mirror:
+        print("mirror: scrcpy not installed (brew install scrcpy) — keeping "
+              "awake without a window", flush=True)
+
+    def stop(*_):
+        if proc and proc.poll() is None:
+            proc.terminate()
+        raise SystemExit(0)
+    signal.signal(signal.SIGTERM, stop)
+    signal.signal(signal.SIGINT, stop)
+    try:
+        was_locked = None
+        while True:
+            if proc and proc.poll() is not None:
+                print("mirror closed — ending", flush=True)
+                return 0
+            try:
+                awake, locked = phone._screen_status()
+            except RuntimeError:
+                print("phone gone — ending", flush=True)
+                return 0
+            if not awake and was_locked is not False:
+                phone._sh("input keyevent KEYCODE_WAKEUP")
+                awake, locked = phone._screen_status()
+            if locked:
+                if was_locked is not True:
+                    print("locked — unlock the phone to continue (pokes paused)",
+                          flush=True)
+                was_locked = True
+            else:
+                if was_locked is not False:
+                    print("unlocked — keeping awake", flush=True)
+                was_locked = False
+                phone._sh(POKE)
+            time.sleep(POKE_EVERY if not locked else 3)
+    finally:
+        if proc and proc.poll() is None:
+            proc.terminate()
+        try:
+            PIDFILE.unlink()
+        except OSError:
+            pass
+
+
+def _awake_pid():
+    """pid of a running awake session (not ourselves), else None."""
+    try:
+        pid = int(PIDFILE.read_text().strip())
+        if pid == os.getpid():
+            return None
+        os.kill(pid, 0)
+        return pid
+    except (OSError, ValueError):
+        return None
+
 
 
 def _connect_serial(serial, timeout=10):
@@ -544,6 +648,47 @@ def cli(args):
         if lan:
             print("paired phones on this Wi-Fi:",
                   ", ".join(f"{s['serial']}@{s['addr']}" for s in lan))
+        pid = _awake_pid()
+        print(f"awake session: {'running (pid %d) — phone-harness android rest to end' % pid if pid else 'off'}")
+        return 0
+
+    if cmd == "awake":
+        if _awake_pid():
+            print(f"already awake (pid {_awake_pid()}); phone-harness android rest to end")
+            return 0
+        mirror = "--no-mirror" not in args
+        if "--bg" in args:
+            child = subprocess.Popen(
+                [sys.executable, "-m", "phone_harness.run", "android", "awake",
+                 "--fg"] + (["--no-mirror"] if not mirror else []),
+                stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+                start_new_session=True)
+            CONFIG.parent.mkdir(parents=True, exist_ok=True)
+            PIDFILE.write_text(str(child.pid))
+            time.sleep(2)
+            print(f"awake in background (pid {child.pid}); phone-harness android rest to end"
+                  if child.poll() is None else "awake exited at once — is a phone connected? try without --bg")
+            return 0 if child.poll() is None else 1
+        CONFIG.parent.mkdir(parents=True, exist_ok=True)
+        PIDFILE.write_text(str(os.getpid()))
+        return _awake(mirror=mirror)
+
+    if cmd == "rest":
+        pid = _awake_pid()
+        if pid:
+            os.kill(pid, signal.SIGTERM)
+            for _ in range(20):
+                if _awake_pid() is None:
+                    break
+                time.sleep(0.2)
+            print("awake session ended")
+        else:
+            print("no awake session running")
+        try:
+            _run("shell", "input", "keyevent", "KEYCODE_SLEEP", timeout=10)
+            print("phone put to sleep")
+        except RuntimeError:
+            pass
         return 0
 
     if cmd == "pair":

--- a/src/phone_harness/android.py
+++ b/src/phone_harness/android.py
@@ -1,0 +1,319 @@
+"""Android backend: the op vocabulary over adb.
+
+Everything here is `adb shell` — no agent app on the phone, no Appium, no
+window to find. adb reaches the device directly, which is what makes three
+things simply better than over iPhone Mirroring:
+
+- Nothing needs focus. Captures and input never care what the Mac is doing,
+  so focus.probe/diff always report "nothing disturbed" and session.refocus
+  is a no-op.
+- Coordinates are device pixels and screen.bounds is the whole display, so a
+  text box's center is already a valid tap target — no scaling.
+- The device has a real accessibility tree (uiautomator), so screen.text is
+  exact where iOS has to recognise glyphs. Pixel OCR stays available as
+  screen.text_pixels for what a tree cannot see: games, canvas, WebViews
+  without accessibility.
+
+Connecting is the phone's own developer path — Settings > Developer options
+> USB debugging, plug in, tap Allow — or Wireless debugging + `adb pair`.
+`ANDROID_SERIAL` picks a device when several are attached; adb honours it.
+An emulator is indistinguishable from a phone here, which is how this was
+developed.
+"""
+import os
+import re
+import shlex
+import subprocess
+import tempfile
+import time
+import xml.etree.ElementTree as ET
+
+from .transport import Backend, Unsupported
+
+ADB = os.environ.get("PHONE_HARNESS_ADB", "adb")
+
+# input.keys names -> Android keycodes. Modifier chords are not a thing
+# `input keyevent` can express, so combos raise rather than half-work.
+_KEYS = {
+    "enter": "ENTER", "return": "ENTER", "tab": "TAB", "space": "SPACE",
+    "delete": "DEL", "backspace": "DEL", "escape": "ESCAPE", "esc": "ESCAPE",
+    "home": "HOME", "back": "BACK", "recents": "APP_SWITCH", "menu": "MENU",
+    "up": "DPAD_UP", "down": "DPAD_DOWN", "left": "DPAD_LEFT",
+    "right": "DPAD_RIGHT", "power": "POWER", "volumeup": "VOLUME_UP",
+    "volumedown": "VOLUME_DOWN", "search": "SEARCH",
+}
+
+
+class Android(Backend):
+    name = "android"
+
+    def __init__(self, serial=None):
+        if serial:
+            os.environ["ANDROID_SERIAL"] = serial
+        self._bounds = None
+
+    # --- adb plumbing -------------------------------------------------------
+
+    def _adb(self, *args, binary=False, timeout=60):
+        r = subprocess.run([ADB, *args], capture_output=True, timeout=timeout)
+        if r.returncode != 0:
+            err = (r.stderr or r.stdout).decode(errors="replace").strip()
+            raise RuntimeError(f"adb {' '.join(args)} failed: {err}")
+        return r.stdout if binary else r.stdout.decode(errors="replace")
+
+    def _sh(self, cmd, timeout=60):
+        return self._adb("shell", cmd, timeout=timeout)
+
+    def _devices(self):
+        """[(serial, state)] as `adb devices` sees them."""
+        out = self._adb("devices")
+        rows = [l.split("\t") for l in out.splitlines()[1:] if "\t" in l]
+        want = os.environ.get("ANDROID_SERIAL")
+        return [(s, st) for s, st in rows if not want or s == want]
+
+    # --- screen -------------------------------------------------------------
+
+    def _screen_bounds(self):
+        if self._bounds is None:
+            try:
+                out = self._sh("wm size")
+            except RuntimeError:
+                return None
+            m = (re.search(r"Override size:\s*(\d+)x(\d+)", out)
+                 or re.search(r"Physical size:\s*(\d+)x(\d+)", out))
+            if not m:
+                return None
+            serial = next((s for s, st in self._devices() if st == "device"),
+                          None)
+            self._bounds = {"x": 0, "y": 0, "w": int(m.group(1)),
+                            "h": int(m.group(2)), "id": serial}
+        return self._bounds
+
+    def _screen_require(self):
+        b = self._screen_bounds()
+        if b is None:
+            return self._session_require()
+        return b
+
+    def _screen_capture(self, path=None):
+        png = self._adb("exec-out", "screencap", "-p", binary=True)
+        if path is None:
+            fd, path = tempfile.mkstemp(prefix="phone-android-", suffix=".png")
+            os.close(fd)
+        with open(path, "wb") as f:
+            f.write(png)
+        return path, self._screen_require()
+
+    def _screen_text(self, min_confidence=0.3):
+        """From the accessibility tree: exact strings, exact boxes."""
+        out = []
+        for n in self._tree():
+            s = n["text"] or n["desc"]
+            if s:
+                out.append({"text": s, "confidence": 1.0, "source": "tree",
+                            "x": n["x"], "y": n["y"], "w": n["w"], "h": n["h"]})
+        return out
+
+    def _screen_text_pixels(self, min_confidence=0.3):
+        from . import ocr as _vision
+        path, win = self._screen_capture()
+        return [dict(o, source="pixels")
+                for o in _vision.recognize(path, win)
+                if o["confidence"] >= min_confidence]
+
+    # --- input --------------------------------------------------------------
+
+    def _input_tap(self, x, y):
+        self._sh(f"input tap {int(x)} {int(y)}")
+
+    def _input_press(self, x, y, duration=0.8):
+        x, y = int(x), int(y)
+        self._sh(f"input swipe {x} {y} {x} {y} {int(duration * 1000)}")
+
+    def _input_drag(self, x1, y1, x2, y2, duration=0.35, steps=14):
+        self._sh(f"input swipe {int(x1)} {int(y1)} {int(x2)} {int(y2)} "
+                 f"{int(duration * 1000)}")
+
+    def _input_scroll(self, x, y, dy, steps=6):
+        """A finger drag standing in for a wheel: +dy moves content up the
+        way wheel-up does (revealing what is above), so the finger travels
+        +dy pixels downward. Slow enough not to fling."""
+        self._sh(f"input swipe {int(x)} {int(y)} {int(x)} {int(y + dy)} "
+                 f"{max(150, int(steps) * 50)}")
+
+    def _input_keys(self, combo):
+        parts = [p.strip().lower() for p in combo.split("+")]
+        if len(parts) > 1:
+            raise Unsupported(f"android cannot press chords ({combo!r}); "
+                              "adb keyevents are single keys")
+        k = parts[0]
+        code = _KEYS.get(k) or (k.upper() if len(k) == 1 and k.isalnum()
+                                else None)
+        if code is None:
+            raise Unsupported(f"android has no key named {combo!r}")
+        self._sh(f"input keyevent KEYCODE_{code}")
+
+    def _input_text(self, s, delay=0.03):
+        """`input text` takes one ASCII token; newlines and backspaces become
+        keyevents, spaces become %s, and the rest is shell-quoted."""
+        for i, line in enumerate(s.split("\n")):
+            if i:
+                self._sh("input keyevent KEYCODE_ENTER")
+            for j, chunk in enumerate(line.split("\b")):
+                if j:
+                    self._sh("input keyevent KEYCODE_DEL")
+                if chunk:
+                    self._sh("input text " + shlex.quote(chunk.replace(" ", "%s")))
+
+    # --- navigation ---------------------------------------------------------
+
+    def _nav_home(self):
+        self._sh("input keyevent KEYCODE_HOME")
+        time.sleep(0.5)
+
+    def _nav_back(self):
+        self._sh("input keyevent KEYCODE_BACK")
+        time.sleep(0.3)
+
+    def _nav_recents(self):
+        self._sh("input keyevent KEYCODE_APP_SWITCH")
+        time.sleep(0.5)
+
+    # --- apps ---------------------------------------------------------------
+
+    def _apps_launch(self, name):
+        """A package id, or a name matched against installed package ids
+        ('chrome' -> com.android.chrome). Returns the package launched."""
+        pkg = name if "." in name else None
+        if pkg is None:
+            pkgs = self._apps_list(include_system=True)
+            hits = [p for p in pkgs if name.lower() in p.lower()]
+            if not hits:
+                raise RuntimeError(f"no installed app matches {name!r}")
+            # shortest match is the least-qualified, e.g. com.android.chrome
+            # over com.android.chrome.helper
+            pkg = sorted(hits, key=len)[0]
+        out = self._sh("cmd package resolve-activity --brief "
+                       f"-c android.intent.category.LAUNCHER {shlex.quote(pkg)}")
+        comp = next((l.strip() for l in reversed(out.splitlines())
+                     if "/" in l), None)
+        if comp is None:
+            raise RuntimeError(f"{pkg} has no launchable activity")
+        self._sh(f"am start -W -n {shlex.quote(comp)}")
+        return pkg
+
+    def _apps_current(self):
+        out = self._sh("dumpsys activity activities")
+        m = (re.search(r"topResumedActivity=ActivityRecord\{[^}]*?\bu\d+ ([\w.]+)/", out)
+             or re.search(r"mResumedActivity: ActivityRecord\{[^}]*?\bu\d+ ([\w.]+)/", out))
+        return m.group(1) if m else None
+
+    def _apps_list(self, include_system=False):
+        out = self._sh("pm list packages" + ("" if include_system else " -3"))
+        return sorted(l[len("package:"):].strip()
+                      for l in out.splitlines() if l.startswith("package:"))
+
+    # --- session ------------------------------------------------------------
+
+    def _session_state(self):
+        """'ready' | 'unauthorized' | 'offline' | 'no-device' | 'no-adb'."""
+        try:
+            devs = self._devices()
+        except (RuntimeError, FileNotFoundError):
+            return "no-adb"
+        states = [st for _, st in devs]
+        if "device" in states:
+            return "ready"
+        if "unauthorized" in states:
+            return "unauthorized"
+        if states:
+            return "offline"
+        return "no-device"
+
+    def _session_detail(self):
+        try:
+            return self._adb("devices", "-l").strip()
+        except Exception as e:
+            return str(e)
+
+    def _session_require(self):
+        """Bounds if a device is ready, else raise telling the USER what to do
+        — plugging in, tapping Allow, and pairing are all physical."""
+        state = self._session_state()
+        if state == "ready":
+            b = self._screen_bounds()
+            if b is not None:
+                return b
+            raise RuntimeError("an Android device is attached but `wm size` "
+                               "gave no screen size; is it still booting?")
+        if state == "no-adb":
+            raise RuntimeError(
+                "adb isn't available. Install Android platform-tools "
+                "(brew install android-platform-tools) or set "
+                "PHONE_HARNESS_ADB to the adb binary, then retry.")
+        if state == "unauthorized":
+            raise RuntimeError(
+                "The Android phone is attached but hasn't authorised this "
+                "computer. Unlock it and tap Allow on the 'Allow USB "
+                "debugging?' prompt (tick 'Always allow'), then retry.")
+        if state == "offline":
+            raise RuntimeError(
+                "adb sees the Android device but it is offline. Unplug and "
+                "replug it (or re-pair over Wireless debugging), then retry.")
+        raise RuntimeError(
+            "No Android device is connected. On the phone: Settings > About "
+            "phone > tap Build number 7 times, then Settings > Developer "
+            "options > USB debugging, plug it in and tap Allow — or use "
+            "Wireless debugging and `adb pair`. Then retry. "
+            f"({self._session_detail()})")
+
+    def _session_refocus(self):
+        return None                    # adb needs nothing in front
+
+    # --- interruption -------------------------------------------------------
+
+    def _focus_probe(self):
+        return (True,)                 # frontmost: adb is never occluded
+
+    def _focus_diff(self, before, after):
+        return {"raised": False, "stole_focus": False}
+
+    # --- tree / raw ---------------------------------------------------------
+
+    def _tree(self):
+        """[{text, desc, id, class, clickable, x, y, w, h}] from
+        `uiautomator dump`, retried briefly: it refuses while the UI is
+        settling ("could not get idle state")."""
+        last = None
+        for _ in range(4):
+            try:
+                raw = self._adb("exec-out", "uiautomator", "dump", "/dev/tty",
+                                binary=True, timeout=30)
+                xml = raw[raw.find(b"<?xml"):]
+                xml = xml[:xml.rfind(b">") + 1]
+                root = ET.fromstring(xml)
+                break
+            except (RuntimeError, ET.ParseError) as e:
+                last = e
+                time.sleep(0.5)
+        else:
+            raise RuntimeError(f"uiautomator dump failed: {last}")
+        nodes = []
+        for el in root.iter("node"):
+            m = re.match(r"\[(\d+),(\d+)\]\[(\d+),(\d+)\]", el.get("bounds", ""))
+            if not m:
+                continue
+            x1, y1, x2, y2 = map(int, m.groups())
+            nodes.append({
+                "text": el.get("text", ""), "desc": el.get("content-desc", ""),
+                "id": el.get("resource-id", ""),
+                "class": el.get("class", ""),
+                "clickable": el.get("clickable") == "true",
+                "x": (x1 + x2) // 2, "y": (y1 + y2) // 2,
+                "w": x2 - x1, "h": y2 - y1,
+            })
+        return nodes
+
+    def _raw(self, cmd, binary=False, timeout=60):
+        """`adb shell <cmd>` — the escape hatch."""
+        return self._adb("shell", cmd, binary=binary, timeout=timeout)

--- a/src/phone_harness/android.py
+++ b/src/phone_harness/android.py
@@ -150,6 +150,11 @@ class Android(Backend):
     # --- adb plumbing -------------------------------------------------------
 
     def _adb(self, *args, binary=False, timeout=60):
+        """Every device-side command pins the device first: adb may list one
+        phone twice over Wi-Fi (by ip:port and by its mDNS name), and an
+        unpinned command then fails with "more than one device"."""
+        if not self._resolved and self._resolve() is None:
+            self._session_require()               # raises with the physical step
         return _run(*args, binary=binary, timeout=timeout)
 
     def _sh(self, cmd, timeout=60):
@@ -476,14 +481,23 @@ class Android(Backend):
             try:
                 raw = self._adb("exec-out", "uiautomator", "dump", "/dev/tty",
                                 binary=True, timeout=30)
-                xml = raw[raw.find(b"<?xml"):]
-                xml = xml[:xml.rfind(b">") + 1]
+                start = raw.find(b"<?xml")
+                if start < 0:                        # uiautomator printed an error, not a tree
+                    last = raw.decode(errors="replace").strip() or "empty dump"
+                    raise ValueError(last)
+                xml = raw[start:raw.rfind(b">") + 1]
                 root = ET.fromstring(xml)
                 break
-            except (RuntimeError, ET.ParseError) as e:
-                last = e
+            except (RuntimeError, ValueError, ET.ParseError) as e:
+                last = str(e)
                 time.sleep(0.5 * (i + 1))          # 0.5, 1, 1.5, 2s: transitions settle
         else:
+            if "idle" in (last or ""):
+                raise RuntimeError(
+                    "the accessibility tree is unavailable on this screen: it "
+                    "never goes idle (something animates or auto-refreshes), so "
+                    "uiautomator will not dump it. Read it from screenshot() "
+                    "instead, or navigate to a screen that settles.")
             raise RuntimeError(f"uiautomator dump failed: {last}")
         nodes = []
         for el in root.iter("node"):

--- a/src/phone_harness/android.py
+++ b/src/phone_harness/android.py
@@ -703,10 +703,12 @@ def cli(args):
         else:
             print("no awake session running")
         try:
-            _run("shell", "input", "keyevent", "KEYCODE_SLEEP", timeout=10)
-            print("phone put to sleep")
-        except RuntimeError:
-            pass
+            phone = Android()
+            if phone._resolve() is not None:
+                phone._sh("input keyevent KEYCODE_SLEEP", timeout=10)
+                print("phone put to sleep")
+        except RuntimeError as e:
+            print(f"(could not put the phone to sleep: {e})")
         return 0
 
     if cmd == "pair":

--- a/src/phone_harness/android.py
+++ b/src/phone_harness/android.py
@@ -1,25 +1,30 @@
-"""Android backend: the op vocabulary over adb.
+"""Android backend: the op vocabulary over adb, and nothing else.
 
-Everything here is `adb shell` — no agent app on the phone, no Appium, no
-window to find. adb reaches the device directly, which is what makes three
-things simply better than over iPhone Mirroring:
+No agent app on the phone, no Appium, no window to find, no OCR: `screencap`
+is the capture and `uiautomator dump` is the tree, so screen.text answers
+exactly (source: "tree") where iOS has to recognise glyphs. adb reaches the
+device directly, so focus.probe/diff report nothing disturbed and
+session.refocus is a no-op. Coordinates are device pixels and screen.bounds
+is the whole display: a text box's centre is already a tap target.
 
-- Nothing needs focus. Captures and input never care what the Mac is doing,
-  so focus.probe/diff always report "nothing disturbed" and session.refocus
-  is a no-op.
-- Coordinates are device pixels and screen.bounds is the whole display, so a
-  text box's center is already a valid tap target — no scaling.
-- The device has a real accessibility tree (uiautomator), so screen.text is
-  exact where iOS has to recognise glyphs. Pixel OCR stays available as
-  screen.text_pixels for what a tree cannot see: games, canvas, WebViews
-  without accessibility.
+Connecting is the phone's own developer path, over USB or Wi-Fi:
 
-Connecting is the phone's own developer path — Settings > Developer options
-> USB debugging, plug in, tap Allow — or Wireless debugging + `adb pair`.
-`ANDROID_SERIAL` picks a device when several are attached; adb honours it.
-An emulator is indistinguishable from a phone here, which is how this was
-developed.
+    USB       Developer options > USB debugging, plug in, tap Allow.
+    Wireless  Developer options > Wireless debugging > Pair device with
+              pairing code, then:  phone-harness android pair IP:PORT CODE
+
+The agent never picks a device. session.require — which every helper passes
+through — resolves one: a USB phone if one is plugged in, else a live
+wireless link (the saved primary first), else a paired phone found on the
+LAN over mDNS and connected on the spot, else a message naming the physical
+step that is missing. Paired phones are
+remembered in ~/.config/phone-harness/android.json under a friendly name and
+matched by hardware serial, so a phone whose Wi-Fi port changed overnight is
+still "pixel-8". The first phone paired over Wi-Fi becomes the primary;
+`phone-harness android use NAME` changes that; ANDROID_SERIAL overrides
+everything.
 """
+import json
 import os
 import re
 import shlex
@@ -27,10 +32,14 @@ import subprocess
 import tempfile
 import time
 import xml.etree.ElementTree as ET
+from datetime import datetime, timezone
+from pathlib import Path
 
 from .transport import Backend, Unsupported
 
 ADB = os.environ.get("PHONE_HARNESS_ADB", "adb")
+CONFIG = Path(os.environ.get("PHONE_HARNESS_CONFIG_DIR",
+                             Path.home() / ".config" / "phone-harness")) / "android.json"
 
 # input.keys names -> Android keycodes. Modifier chords are not a thing
 # `input keyevent` can express, so combos raise rather than half-work.
@@ -44,6 +53,85 @@ _KEYS = {
 }
 
 
+# --- adb, without a device yet -----------------------------------------------
+
+def _run(*args, binary=False, timeout=60, check=True):
+    r = subprocess.run([ADB, *args], capture_output=True, timeout=timeout)
+    if check and r.returncode != 0:
+        err = (r.stderr or r.stdout).decode(errors="replace").strip()
+        raise RuntimeError(f"adb {' '.join(args)} failed: {err}")
+    return r.stdout if binary else r.stdout.decode(errors="replace")
+
+
+def _attached():
+    """[(adb_id, state, transport)] — transport is 'usb' or 'wifi'."""
+    rows = [l.split() for l in _run("devices").splitlines()[1:] if l.strip()]
+    return [(r[0], r[1], "wifi" if ":" in r[0] or r[0].startswith("adb-")
+             else "usb") for r in rows if len(r) >= 2]
+
+
+def _prop(adb_id, name):
+    return _run("-s", adb_id, "shell", "getprop", name, timeout=15).strip()
+
+
+def _mdns():
+    """Paired phones announcing themselves on the LAN:
+    [{serial, host, port, addr}] for _adb-tls-connect services. The service
+    name carries the hardware serial: adb-<SERIAL>-<suffix>."""
+    out = _run("mdns", "services", check=False)
+    found = []
+    for line in out.splitlines():
+        parts = line.split("\t") if "\t" in line else line.split()
+        if len(parts) < 3 or "_adb-tls-connect" not in parts[1]:
+            continue
+        m = re.match(r"adb-(.+)-[^-]+$", parts[0])
+        host, _, port = parts[2].rpartition(":")
+        if m and host and port.isdigit():
+            found.append({"serial": m.group(1), "host": host,
+                          "port": int(port), "addr": parts[2]})
+    return found
+
+
+# --- the registry: phones we know, and which one is primary -----------------
+
+def _load():
+    try:
+        return json.loads(CONFIG.read_text())
+    except (OSError, ValueError):
+        return {"primary": None, "phones": {}}
+
+
+def _store(cfg):
+    CONFIG.parent.mkdir(parents=True, exist_ok=True)
+    CONFIG.write_text(json.dumps(cfg, indent=2) + "\n")
+
+
+def _now():
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _remember(cfg, serial, model, host=None, name=None, primary=False):
+    """Upsert a phone by serial. `primary=True` makes it the primary if there
+    is none yet — passed by wireless pairing, not by a phone that merely
+    showed up on USB: the primary is which phone to reach for over Wi-Fi."""
+    phones = cfg.setdefault("phones", {})
+    key = next((k for k, p in phones.items() if p.get("serial") == serial), None)
+    if key is None:
+        base = name or re.sub(r"[^a-z0-9]+", "-", (model or "android").lower()).strip("-")
+        key, n = base, 2
+        while key in phones:
+            key, n = f"{base}-{n}", n + 1
+        phones[key] = {"serial": serial, "model": model, "paired": _now()}
+    p = phones[key]
+    p["last_seen"] = _now()
+    if host:
+        p["last_host"] = host
+    if primary and not cfg.get("primary"):
+        cfg["primary"] = key
+    _store(cfg)
+    return key
+
+
 class Android(Backend):
     name = "android"
 
@@ -51,30 +139,77 @@ class Android(Backend):
         if serial:
             os.environ["ANDROID_SERIAL"] = serial
         self._bounds = None
+        self._resolved = False
 
     # --- adb plumbing -------------------------------------------------------
 
     def _adb(self, *args, binary=False, timeout=60):
-        r = subprocess.run([ADB, *args], capture_output=True, timeout=timeout)
-        if r.returncode != 0:
-            err = (r.stderr or r.stdout).decode(errors="replace").strip()
-            raise RuntimeError(f"adb {' '.join(args)} failed: {err}")
-        return r.stdout if binary else r.stdout.decode(errors="replace")
+        return _run(*args, binary=binary, timeout=timeout)
 
     def _sh(self, cmd, timeout=60):
         return self._adb("shell", cmd, timeout=timeout)
 
-    def _devices(self):
-        """[(serial, state)] as `adb devices` sees them."""
-        out = self._adb("devices")
-        rows = [l.split("\t") for l in out.splitlines()[1:] if "\t" in l]
-        want = os.environ.get("ANDROID_SERIAL")
-        return [(s, st) for s, st in rows if not want or s == want]
+    # --- choosing the phone -------------------------------------------------
+
+    def _resolve(self):
+        """Pin ANDROID_SERIAL to one ready device, connecting a paired phone
+        over Wi-Fi if nothing is attached. Returns the adb id or None.
+
+        Order: the user's explicit ANDROID_SERIAL; then a USB phone (wired
+        always wins — it is right there); then a live Wi-Fi link, the saved
+        primary first; then mDNS — the primary if it is on the LAN, else the
+        first known phone, else any paired phone."""
+        if os.environ.get("ANDROID_SERIAL"):
+            self._resolved = True
+            return os.environ["ANDROID_SERIAL"]
+        cfg = _load()
+        primary = (cfg.get("phones") or {}).get(cfg.get("primary") or "", {})
+        known = {p.get("serial") for p in (cfg.get("phones") or {}).values()}
+
+        def pick(ready):
+            usb = [r for r in ready if r[2] == "usb"]
+            if usb:
+                return usb[0][0]
+            wifi = [r for r in ready if r[2] == "wifi"]
+            if primary.get("serial"):
+                for adb_id, _, _ in wifi:
+                    try:
+                        if _prop(adb_id, "ro.serialno") == primary["serial"]:
+                            return adb_id
+                    except RuntimeError:
+                        pass
+            return wifi[0][0] if wifi else None
+
+        ready = [r for r in _attached() if r[1] == "device"]
+        chosen = pick(ready)
+        if chosen is None:
+            wanted = [primary.get("serial")] + sorted(known - {primary.get("serial")})
+            services = _mdns()
+            services.sort(key=lambda s: (wanted.index(s["serial"])
+                                         if s["serial"] in wanted else len(wanted)))
+            for s in services:
+                out = _run("connect", s["addr"], timeout=15, check=False)
+                if "connected" in out and "cannot" not in out:
+                    break
+            ready = [r for r in _attached() if r[1] == "device"]
+            chosen = pick(ready)
+        if chosen is not None:
+            os.environ["ANDROID_SERIAL"] = chosen
+            self._resolved = True
+            try:
+                _remember(cfg, _prop(chosen, "ro.serialno"),
+                          _prop(chosen, "ro.product.model"),
+                          host=chosen.rpartition(":")[0] if ":" in chosen else None)
+            except RuntimeError:
+                pass
+        return chosen
 
     # --- screen -------------------------------------------------------------
 
     def _screen_bounds(self):
         if self._bounds is None:
+            if self._resolve() is None:
+                return None
             try:
                 out = self._sh("wm size")
             except RuntimeError:
@@ -83,26 +218,24 @@ class Android(Backend):
                  or re.search(r"Physical size:\s*(\d+)x(\d+)", out))
             if not m:
                 return None
-            serial = next((s for s, st in self._devices() if st == "device"),
-                          None)
             self._bounds = {"x": 0, "y": 0, "w": int(m.group(1)),
-                            "h": int(m.group(2)), "id": serial}
+                            "h": int(m.group(2)),
+                            "id": os.environ.get("ANDROID_SERIAL")}
         return self._bounds
 
     def _screen_require(self):
         b = self._screen_bounds()
-        if b is None:
-            return self._session_require()
-        return b
+        return b if b is not None else self._session_require()
 
     def _screen_capture(self, path=None):
+        bounds = self._screen_require()
         png = self._adb("exec-out", "screencap", "-p", binary=True)
         if path is None:
             fd, path = tempfile.mkstemp(prefix="phone-android-", suffix=".png")
             os.close(fd)
         with open(path, "wb") as f:
             f.write(png)
-        return path, self._screen_require()
+        return path, bounds
 
     def _screen_text(self, min_confidence=0.3):
         """From the accessibility tree: exact strings, exact boxes."""
@@ -114,12 +247,9 @@ class Android(Backend):
                             "x": n["x"], "y": n["y"], "w": n["w"], "h": n["h"]})
         return out
 
-    def _screen_text_pixels(self, min_confidence=0.3):
-        from . import ocr as _vision
-        path, win = self._screen_capture()
-        return [dict(o, source="pixels")
-                for o in _vision.recognize(path, win)
-                if o["confidence"] >= min_confidence]
+    # No _screen_text_pixels: the tree is the text source here, and a caller
+    # that needs pixels can look at screen.capture. Keeps this backend free of
+    # anything but adb.
 
     # --- input --------------------------------------------------------------
 
@@ -218,12 +348,11 @@ class Android(Backend):
     def _session_state(self):
         """'ready' | 'unauthorized' | 'offline' | 'no-device' | 'no-adb'."""
         try:
-            devs = self._devices()
+            if self._resolve() is not None:
+                return "ready"
+            states = [st for _, st, _ in _attached()]
         except (RuntimeError, FileNotFoundError):
             return "no-adb"
-        states = [st for _, st in devs]
-        if "device" in states:
-            return "ready"
         if "unauthorized" in states:
             return "unauthorized"
         if states:
@@ -232,12 +361,12 @@ class Android(Backend):
 
     def _session_detail(self):
         try:
-            return self._adb("devices", "-l").strip()
+            return _run("devices", "-l").strip()
         except Exception as e:
             return str(e)
 
     def _session_require(self):
-        """Bounds if a device is ready, else raise telling the USER what to do
+        """Bounds if a phone is ready, else raise telling the USER what to do
         — plugging in, tapping Allow, and pairing are all physical."""
         state = self._session_state()
         if state == "ready":
@@ -259,13 +388,18 @@ class Android(Backend):
         if state == "offline":
             raise RuntimeError(
                 "adb sees the Android device but it is offline. Unplug and "
-                "replug it (or re-pair over Wireless debugging), then retry.")
+                "replug it (or toggle Wireless debugging off and on), then retry.")
+        cfg = _load()
+        prim = cfg.get("primary")
+        known = (f" Your primary phone is '{prim}' — make sure Wireless "
+                 "debugging is on and it is on this Wi-Fi; if it forgot this "
+                 "Mac, pair again." if prim else "")
         raise RuntimeError(
-            "No Android device is connected. On the phone: Settings > About "
-            "phone > tap Build number 7 times, then Settings > Developer "
-            "options > USB debugging, plug it in and tap Allow — or use "
-            "Wireless debugging and `adb pair`. Then retry. "
-            f"({self._session_detail()})")
+            "No Android device is reachable." + known + " To connect one: "
+            "USB — Settings > Developer options > USB debugging, plug in, tap "
+            "Allow. Wi-Fi — Developer options > Wireless debugging > Pair "
+            "device with pairing code, then `phone-harness android pair "
+            "IP:PORT CODE`. Then retry.")
 
     def _session_refocus(self):
         return None                    # adb needs nothing in front
@@ -284,6 +418,7 @@ class Android(Backend):
         """[{text, desc, id, class, clickable, x, y, w, h}] from
         `uiautomator dump`, retried briefly: it refuses while the UI is
         settling ("could not get idle state")."""
+        self._screen_require()
         last = None
         for _ in range(4):
             try:
@@ -316,4 +451,116 @@ class Android(Backend):
 
     def _raw(self, cmd, binary=False, timeout=60):
         """`adb shell <cmd>` — the escape hatch."""
+        self._screen_require()
         return self._adb("shell", cmd, binary=binary, timeout=timeout)
+
+
+# --- CLI (phone-harness android ...) ----------------------------------------
+
+CLI_USAGE = """Usage:
+  phone-harness android                          known phones, primary, what's live
+  phone-harness android pair IP:PORT CODE [NAME] Wireless debugging: pair, connect, remember
+  phone-harness android connect [NAME|IP:PORT]   connect a paired phone (default: primary, via mDNS)
+  phone-harness android use NAME                 make NAME the primary
+  phone-harness android forget NAME
+"""
+
+
+def _connect_serial(serial, timeout=10):
+    """Find `serial` on the LAN and adb-connect it; -> adb id or None."""
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        for s in _mdns():
+            if s["serial"] == serial:
+                out = _run("connect", s["addr"], timeout=15, check=False)
+                if "connected" in out and "cannot" not in out:
+                    return s["addr"]
+        time.sleep(1)
+    return None
+
+
+def cli(args):
+    cmd = args[0] if args else None
+    cfg = _load()
+    phones = cfg.get("phones") or {}
+
+    if cmd is None:
+        live = {a: (st, tr) for a, st, tr in _attached()}
+        print(f"primary: {cfg.get('primary') or '(none)'}   config: {CONFIG}")
+        for name, p in phones.items():
+            mark = "*" if name == cfg.get("primary") else " "
+            print(f" {mark} {name:<16} {p.get('model') or '?':<18} serial {p.get('serial')}"
+                  f"   last {p.get('last_host') or '-'} @ {p.get('last_seen', '-')[:16]}")
+        print("attached now:", ", ".join(f"{a} ({st}, {tr})" for a, (st, tr) in live.items())
+              or "nothing")
+        lan = _mdns()
+        if lan:
+            print("paired phones on this Wi-Fi:",
+                  ", ".join(f"{s['serial']}@{s['addr']}" for s in lan))
+        return 0
+
+    if cmd == "pair":
+        if len(args) < 3:
+            print(CLI_USAGE); return 2
+        addr, code = args[1], args[2]
+        name = args[3] if len(args) > 3 else None
+        out = _run("pair", addr, code, timeout=30, check=False)
+        if "Successfully paired" not in out:
+            print(out.strip() or "pairing failed"); return 1
+        host = addr.rpartition(":")[0]
+        # the connect port differs from the pairing port; find it via mDNS
+        adb_id = None
+        for _ in range(10):
+            hit = next((s for s in _mdns() if s["host"] == host), None)
+            if hit:
+                o = _run("connect", hit["addr"], timeout=15, check=False)
+                if "connected" in o and "cannot" not in o:
+                    adb_id = hit["addr"]; break
+            time.sleep(1)
+        if adb_id is None:
+            print("paired, but could not find the phone's connect port on this "
+                  "network yet. Turn Wireless debugging off and on, then: "
+                  "phone-harness android connect IP:PORT  (the port shown on "
+                  "the Wireless debugging screen)")
+            return 1
+        serial, model = _prop(adb_id, "ro.serialno"), _prop(adb_id, "ro.product.model")
+        key = _remember(cfg, serial, model, host=host, name=name, primary=True)
+        cfg = _load()
+        print(f"paired and connected: {model} as '{key}' ({adb_id})"
+              + ("  — now the primary" if cfg.get("primary") == key else ""))
+        return 0
+
+    if cmd == "connect":
+        target = args[1] if len(args) > 1 else cfg.get("primary")
+        if not target:
+            print("no primary phone yet — pair one first"); return 1
+        if ":" in target:
+            out = _run("connect", target, timeout=15, check=False); print(out.strip())
+            return 0 if "connected" in out and "cannot" not in out else 1
+        p = phones.get(target)
+        if not p:
+            print(f"unknown phone {target!r}; known: {', '.join(phones) or 'none'}"); return 1
+        adb_id = _connect_serial(p["serial"])
+        if adb_id is None:
+            print(f"'{target}' isn't announcing on this Wi-Fi. Is Wireless "
+                  "debugging on, and the phone on the same network?"); return 1
+        _remember(cfg, p["serial"], p.get("model"), host=adb_id.rpartition(":")[0],
+                  primary=True)
+        print(f"connected: {target} ({adb_id})"); return 0
+
+    if cmd == "use":
+        if len(args) < 2 or args[1] not in phones:
+            print(f"known phones: {', '.join(phones) or 'none'}"); return 2
+        cfg["primary"] = args[1]; _store(cfg)
+        print(f"primary: {args[1]}"); return 0
+
+    if cmd == "forget":
+        if len(args) < 2 or args[1] not in phones:
+            print(f"known phones: {', '.join(phones) or 'none'}"); return 2
+        phones.pop(args[1])
+        if cfg.get("primary") == args[1]:
+            cfg["primary"] = next(iter(phones), None)
+        _store(cfg); print(f"forgot {args[1]}"); return 0
+
+    print(CLI_USAGE)
+    return 2

--- a/src/phone_harness/android.py
+++ b/src/phone_harness/android.py
@@ -11,7 +11,7 @@ Connecting is the phone's own developer path, over USB or Wi-Fi:
 
     USB       Developer options > USB debugging, plug in, tap Allow.
     Wireless  Developer options > Wireless debugging > Pair device with
-              pairing code, then:  phone-harness android pair IP:PORT CODE
+              pairing code, then:  phone-harness android pair CODE
 
 The agent never picks a device. session.require — which every helper passes
 through — resolves one: a USB phone if one is plugged in, else a live
@@ -77,15 +77,17 @@ def _prop(adb_id, name):
     return _run("-s", adb_id, "shell", "getprop", name, timeout=15).strip()
 
 
-def _mdns():
-    """Paired phones announcing themselves on the LAN:
-    [{serial, host, port, addr}] for _adb-tls-connect services. The service
-    name carries the hardware serial: adb-<SERIAL>-<suffix>."""
+def _mdns(kind="connect"):
+    """Phones announcing themselves on the LAN: [{serial, host, port, addr}]
+    for _adb-tls-connect services (paired phones with Wireless debugging on)
+    or, with kind="pairing", _adb-tls-pairing services (a phone showing its
+    "Pair device with pairing code" dialog right now). The service name
+    carries the hardware serial: adb-<SERIAL>-<suffix>."""
     out = _run("mdns", "services", check=False)
     found = []
     for line in out.splitlines():
         parts = line.split("\t") if "\t" in line else line.split()
-        if len(parts) < 3 or "_adb-tls-connect" not in parts[1]:
+        if len(parts) < 3 or f"_adb-tls-{kind}" not in parts[1]:
             continue
         m = re.match(r"adb-(.+)-[^-]+$", parts[0])
         host, _, port = parts[2].rpartition(":")
@@ -448,7 +450,7 @@ class Android(Backend):
             "USB — Settings > Developer options > USB debugging, plug in, tap "
             "Allow. Wi-Fi — Developer options > Wireless debugging > Pair "
             "device with pairing code, then `phone-harness android pair "
-            "IP:PORT CODE`. Then retry.")
+            "CODE`. Then retry.")
 
     def _session_refocus(self):
         return None                    # adb needs nothing in front
@@ -509,7 +511,9 @@ class Android(Backend):
 
 CLI_USAGE = """Usage:
   phone-harness android                          known phones, primary, what's live
-  phone-harness android pair IP:PORT CODE [NAME] Wireless debugging: pair, connect, remember
+  phone-harness android pair [CODE] [NAME]       Wireless debugging: pair with the 6-digit
+                                                 code (phone found over mDNS), connect, remember
+  phone-harness android pair IP:PORT CODE [NAME] the same, if mDNS is blocked on your network
   phone-harness android connect [NAME|IP:PORT]   connect a paired phone (default: primary, via mDNS)
   phone-harness android use NAME                 make NAME the primary
   phone-harness android forget NAME
@@ -692,10 +696,35 @@ def cli(args):
         return 0
 
     if cmd == "pair":
-        if len(args) < 3:
-            print(CLI_USAGE); return 2
-        addr, code = args[1], args[2]
-        name = args[3] if len(args) > 3 else None
+        # Forms: pair | pair CODE [NAME] | pair IP:PORT CODE [NAME]
+        rest_ = args[1:]
+        if rest_ and ":" in rest_[0]:
+            if len(rest_) < 2:
+                print(CLI_USAGE); return 2
+            addr, code, name = rest_[0], rest_[1], (rest_[2] if len(rest_) > 2 else None)
+        else:
+            code = rest_[0] if rest_ else None
+            name = rest_[1] if len(rest_) > 1 else None
+            print("On the phone: Settings > Developer options > Wireless debugging "
+                  "(on) > 'Pair device with pairing code'. Keep that dialog open.")
+            if not code:
+                try:
+                    code = input("6-digit pairing code shown on the phone: ").strip()
+                except EOFError:
+                    print(CLI_USAGE); return 2
+            print("looking for the phone on this Wi-Fi...", flush=True)
+            addr = None
+            for _ in range(45):                       # the dialog advertises itself
+                hits = _mdns("pairing")
+                if hits:
+                    addr = hits[0]["addr"]; break
+                time.sleep(1)
+            if addr is None:
+                print("no phone is offering to pair on this network. Is Wireless "
+                      "debugging on, the pairing dialog open, and the phone on the "
+                      "same Wi-Fi as this Mac? If your network blocks mDNS, use: "
+                      "phone-harness android pair IP:PORT CODE (both shown in the dialog)")
+                return 1
         out = _run("pair", addr, code, timeout=30, check=False)
         if "Successfully paired" not in out:
             print(out.strip() or "pairing failed"); return 1

--- a/src/phone_harness/android.py
+++ b/src/phone_harness/android.py
@@ -765,6 +765,10 @@ def cli(args):
         cfg = _load()
         print(f"paired and connected: {model} as '{key}' ({adb_id})"
               + ("  — now the primary" if cfg.get("primary") == key else ""))
+        from . import transport
+        if transport.default_platform() != "android":
+            print("tip: `phone-harness use android` makes Android the default, "
+                  "so nothing needs PHONE_HARNESS_PLATFORM=android")
         return 0
 
     if cmd == "connect":

--- a/src/phone_harness/android.py
+++ b/src/phone_harness/android.py
@@ -18,13 +18,12 @@ through — resolves one: a USB phone if one is plugged in, else a live
 wireless link (the saved primary first), else a paired phone found on the
 LAN over mDNS and connected on the spot, else a message naming the physical
 step that is missing. Paired phones are
-remembered in ~/.config/phone-harness/android.json under a friendly name and
+remembered (see config.py: the devices state file) under a friendly name and
 matched by hardware serial, so a phone whose Wi-Fi port changed overnight is
 still "pixel-8". The first phone paired over Wi-Fi becomes the primary;
 `phone-harness android use NAME` changes that; ANDROID_SERIAL overrides
 everything.
 """
-import json
 import os
 import re
 import shlex
@@ -36,13 +35,13 @@ import tempfile
 import time
 import xml.etree.ElementTree as ET
 from datetime import datetime, timezone
-from pathlib import Path
 
+from . import config
 from .transport import Backend, Unsupported
 
-ADB = os.environ.get("PHONE_HARNESS_ADB", "adb")
-CONFIG = Path(os.environ.get("PHONE_HARNESS_CONFIG_DIR",
-                             Path.home() / ".config" / "phone-harness")) / "android.json"
+
+def _adb_bin():
+    return str(config.get("android.adb"))
 
 # input.keys names -> Android keycodes. Modifier chords are not a thing
 # `input keyevent` can express, so combos raise rather than half-work.
@@ -59,7 +58,7 @@ _KEYS = {
 # --- adb, without a device yet -----------------------------------------------
 
 def _run(*args, binary=False, timeout=60, check=True):
-    r = subprocess.run([ADB, *args], capture_output=True, timeout=timeout)
+    r = subprocess.run([_adb_bin(), *args], capture_output=True, timeout=timeout)
     if check and r.returncode != 0:
         err = (r.stderr or r.stdout).decode(errors="replace").strip()
         raise RuntimeError(f"adb {' '.join(args)} failed: {err}")
@@ -100,15 +99,11 @@ def _mdns(kind="connect"):
 # --- the registry: phones we know, and which one is primary -----------------
 
 def _load():
-    try:
-        return json.loads(CONFIG.read_text())
-    except (OSError, ValueError):
-        return {"primary": None, "phones": {}}
+    return config.devices_of("android")
 
 
 def _store(cfg):
-    CONFIG.parent.mkdir(parents=True, exist_ok=True)
-    CONFIG.write_text(json.dumps(cfg, indent=2) + "\n")
+    config.save_devices_of("android", cfg)
 
 
 def _now():
@@ -538,8 +533,12 @@ CLI_USAGE = """Usage:
   phone-harness android rest                     end the session; the phone sleeps
 """
 
-PIDFILE = CONFIG.with_name("awake.pid")
-POKE_EVERY = 25          # seconds; a phone's shortest screen timeout is 15s
+def _pidfile():
+    return config.run_dir() / "awake.pid"
+
+
+def _poke_every():
+    return max(5, int(config.get("android.poke_every")))   # shortest phone timeout is 15s
 POKE = "input keyevent KEYCODE_UNKNOWN"   # counts as user activity; no app sees it
 
 
@@ -557,7 +556,7 @@ def _phone_label(adb_id):
 
 def _awake(mirror=True):
     """The session companion. Wakes the phone; waits for the user to unlock
-    if it is locked; then every POKE_EVERY seconds sends a keypress no app
+    if it is locked; then every android.poke_every seconds sends a keypress no app
     reacts to, which the phone counts as user activity — so it never
     reaches its screen timeout while this runs, on USB or Wi-Fi, charging
     or not, and reverts to normal the instant this stops. No setting is
@@ -612,12 +611,12 @@ def _awake(mirror=True):
                     print("unlocked — keeping awake", flush=True)
                 was_locked = False
                 phone._sh(POKE)
-            time.sleep(POKE_EVERY if not locked else 3)
+            time.sleep(_poke_every() if not locked else 3)
     finally:
         if proc and proc.poll() is None:
             proc.terminate()
         try:
-            PIDFILE.unlink()
+            _pidfile().unlink()
         except OSError:
             pass
 
@@ -625,7 +624,7 @@ def _awake(mirror=True):
 def _awake_pid():
     """pid of a running awake session (not ourselves), else None."""
     try:
-        pid = int(PIDFILE.read_text().strip())
+        pid = int(_pidfile().read_text().strip())
         if pid == os.getpid():
             return None
         os.kill(pid, 0)
@@ -655,7 +654,7 @@ def cli(args):
 
     if cmd is None:
         live = {a: (st, tr) for a, st, tr in _attached()}
-        print(f"primary: {cfg.get('primary') or '(none)'}   config: {CONFIG}")
+        print(f"primary: {cfg.get('primary') or '(none)'}   devices: {config.paths()['devices']}")
         for name, p in phones.items():
             mark = "*" if name == cfg.get("primary") else " "
             print(f" {mark} {name:<16} {p.get('model') or '?':<18} serial {p.get('serial')}"
@@ -674,21 +673,21 @@ def cli(args):
         if _awake_pid():
             print(f"already awake (pid {_awake_pid()}); phone-harness android rest to end")
             return 0
-        mirror = "--no-mirror" not in args
+        mirror = "--no-mirror" not in args and bool(config.get("android.mirror"))
         if "--bg" in args:
             child = subprocess.Popen(
                 [sys.executable, "-m", "phone_harness.run", "android", "awake",
                  "--fg"] + (["--no-mirror"] if not mirror else []),
                 stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
                 start_new_session=True)
-            CONFIG.parent.mkdir(parents=True, exist_ok=True)
-            PIDFILE.write_text(str(child.pid))
+            _pidfile().parent.mkdir(parents=True, exist_ok=True)
+            _pidfile().write_text(str(child.pid))
             time.sleep(2)
             print(f"awake in background (pid {child.pid}); phone-harness android rest to end"
                   if child.poll() is None else "awake exited at once — is a phone connected? try without --bg")
             return 0 if child.poll() is None else 1
-        CONFIG.parent.mkdir(parents=True, exist_ok=True)
-        PIDFILE.write_text(str(os.getpid()))
+        _pidfile().parent.mkdir(parents=True, exist_ok=True)
+        _pidfile().write_text(str(os.getpid()))
         return _awake(mirror=mirror)
 
     if cmd == "rest":
@@ -765,10 +764,9 @@ def cli(args):
         cfg = _load()
         print(f"paired and connected: {model} as '{key}' ({adb_id})"
               + ("  — now the primary" if cfg.get("primary") == key else ""))
-        from . import transport
-        if transport.default_platform() != "android":
-            print("tip: `phone-harness use android` makes Android the default, "
-                  "so nothing needs PHONE_HARNESS_PLATFORM=android")
+        if config.get("platform") != "android":
+            print("tip: `phone-harness config set platform android` makes Android "
+                  "the default, so nothing needs PHONE_HARNESS_PLATFORM=android")
         return 0
 
     if cmd == "connect":

--- a/src/phone_harness/android.py
+++ b/src/phone_harness/android.py
@@ -140,6 +140,7 @@ class Android(Backend):
             os.environ["ANDROID_SERIAL"] = serial
         self._bounds = None
         self._resolved = False
+        self._gate_at = 0.0
 
     # --- adb plumbing -------------------------------------------------------
 
@@ -204,6 +205,35 @@ class Android(Backend):
                 pass
         return chosen
 
+    # --- awake and unlocked? -----------------------------------------------
+
+    def _screen_status(self):
+        """(awake, locked) from two dumpsys reads, ~0.2s. adb happily taps a
+        lock screen and dumps its PIN pad; nothing errors — so we ask."""
+        awake = "Awake" in self._sh("dumpsys power | grep -m1 mWakefulness=")
+        locked = "isKeyguardShowing=true" in self._sh(
+            "dumpsys window | grep -m1 isKeyguardShowing")
+        return awake, locked
+
+    def _gate(self):
+        """Refuse to drive a phone that is asleep or locked. Waking it is
+        harmless and done here; unlocking is the user's — a PIN is never
+        typed for them. Cached for 2s so a burst of taps checks once."""
+        if time.time() - self._gate_at < 2.0:
+            return
+        awake, locked = self._screen_status()
+        if not awake:
+            self._sh("input keyevent KEYCODE_WAKEUP")
+            time.sleep(0.5)
+            awake, locked = self._screen_status()
+        if locked:
+            raise RuntimeError(
+                "The Android phone is locked. Unlock it (PIN / fingerprint), "
+                "then retry — I won't enter a PIN. It re-locks after its screen "
+                "timeout; Settings > Developer options > Stay awake keeps it on "
+                "while charging.")
+        self._gate_at = time.time()
+
     # --- screen -------------------------------------------------------------
 
     def _screen_bounds(self):
@@ -254,13 +284,16 @@ class Android(Backend):
     # --- input --------------------------------------------------------------
 
     def _input_tap(self, x, y):
+        self._gate()
         self._sh(f"input tap {int(x)} {int(y)}")
 
     def _input_press(self, x, y, duration=0.8):
+        self._gate()
         x, y = int(x), int(y)
         self._sh(f"input swipe {x} {y} {x} {y} {int(duration * 1000)}")
 
     def _input_drag(self, x1, y1, x2, y2, duration=0.35, steps=14):
+        self._gate()
         self._sh(f"input swipe {int(x1)} {int(y1)} {int(x2)} {int(y2)} "
                  f"{int(duration * 1000)}")
 
@@ -268,10 +301,12 @@ class Android(Backend):
         """A finger drag standing in for a wheel: +dy moves content up the
         way wheel-up does (revealing what is above), so the finger travels
         +dy pixels downward. Slow enough not to fling."""
+        self._gate()
         self._sh(f"input swipe {int(x)} {int(y)} {int(x)} {int(y + dy)} "
                  f"{max(150, int(steps) * 50)}")
 
     def _input_keys(self, combo):
+        self._gate()
         parts = [p.strip().lower() for p in combo.split("+")]
         if len(parts) > 1:
             raise Unsupported(f"android cannot press chords ({combo!r}); "
@@ -284,6 +319,7 @@ class Android(Backend):
         self._sh(f"input keyevent KEYCODE_{code}")
 
     def _input_text(self, s, delay=0.03):
+        self._gate()
         """`input text` takes one ASCII token; newlines and backspaces become
         keyevents, spaces become %s, and the rest is shell-quoted."""
         for i, line in enumerate(s.split("\n")):
@@ -314,6 +350,7 @@ class Android(Backend):
     def _apps_launch(self, name):
         """A package id, or a name matched against installed package ids
         ('chrome' -> com.android.chrome). Returns the package launched."""
+        self._gate()
         pkg = name if "." in name else None
         if pkg is None:
             pkgs = self._apps_list(include_system=True)
@@ -346,9 +383,15 @@ class Android(Backend):
     # --- session ------------------------------------------------------------
 
     def _session_state(self):
-        """'ready' | 'unauthorized' | 'offline' | 'no-device' | 'no-adb'."""
+        """'ready' | 'locked' | 'unauthorized' | 'offline' | 'no-device' | 'no-adb'."""
         try:
             if self._resolve() is not None:
+                try:
+                    self._gate()
+                except RuntimeError as e:
+                    if "locked" in str(e):
+                        return "locked"
+                    raise
                 return "ready"
             states = [st for _, st, _ in _attached()]
         except (RuntimeError, FileNotFoundError):
@@ -375,6 +418,9 @@ class Android(Backend):
                 return b
             raise RuntimeError("an Android device is attached but `wm size` "
                                "gave no screen size; is it still booting?")
+        if state == "locked":
+            self._gate_at = 0.0
+            self._gate()                       # raises with the unlock message
         if state == "no-adb":
             raise RuntimeError(
                 "adb isn't available. Install Android platform-tools "
@@ -419,8 +465,9 @@ class Android(Backend):
         `uiautomator dump`, retried briefly: it refuses while the UI is
         settling ("could not get idle state")."""
         self._screen_require()
+        self._gate()
         last = None
-        for _ in range(4):
+        for i in range(5):
             try:
                 raw = self._adb("exec-out", "uiautomator", "dump", "/dev/tty",
                                 binary=True, timeout=30)
@@ -430,7 +477,7 @@ class Android(Backend):
                 break
             except (RuntimeError, ET.ParseError) as e:
                 last = e
-                time.sleep(0.5)
+                time.sleep(0.5 * (i + 1))          # 0.5, 1, 1.5, 2s: transitions settle
         else:
             raise RuntimeError(f"uiautomator dump failed: {last}")
         nodes = []

--- a/src/phone_harness/config.py
+++ b/src/phone_harness/config.py
@@ -1,0 +1,275 @@
+"""Where phone-harness keeps what the user chose and what it learned.
+
+Two kinds of thing, kept apart because they live differently:
+
+  config   intent — the default platform, the adb binary, how often to poke
+           a phone awake. Hand-editable, small, worth putting in dotfiles.
+             ~/.config/phone-harness/config.json
+  state    what the harness learned — remembered phones and which is
+           primary, the pid of a running awake session. Machine-managed,
+           rebuildable, never worth backing up.
+             ~/.local/state/phone-harness/devices.json
+             ~/.local/state/phone-harness/run/awake.pid
+
+XDG_CONFIG_HOME / XDG_STATE_HOME are honoured; PHONE_HARNESS_HOME moves both
+roots under one directory (tests, sandboxes).
+
+One rule for every setting: explicit argument, else environment variable,
+else config file, else built-in default. `get("android.poke_every")` looks
+at PHONE_HARNESS_ANDROID_POKE_EVERY, then config.json, then DEFAULTS. Env
+vars are per-call overrides; nothing requires them.
+
+Files are versioned, read forgivingly (a corrupt file is a warning and
+defaults, never a crash) and written atomically. Unknown keys survive a
+round trip. This module owns the disk; backends ask it.
+"""
+import json
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+VERSION = 1
+
+DEFAULTS = {
+    "platform": "ios",
+    "android": {
+        "adb": "adb",          # the binary; a path if it is not on PATH
+        "poke_every": 25,      # seconds between keep-awake pokes
+        "mirror": True,        # open scrcpy during `android awake` if installed
+    },
+}
+
+# Settings that historically had their own environment variable.
+_ENV_ALIASES = {
+    "platform": ["PHONE_HARNESS_PLATFORM"],
+    "android.adb": ["PHONE_HARNESS_ADB"],
+}
+
+
+# --- where -------------------------------------------------------------------
+
+def config_dir():
+    home = os.environ.get("PHONE_HARNESS_HOME")
+    if home:
+        return Path(home) / "config"
+    base = os.environ.get("XDG_CONFIG_HOME") or Path.home() / ".config"
+    return Path(base) / "phone-harness"
+
+
+def state_dir():
+    home = os.environ.get("PHONE_HARNESS_HOME")
+    if home:
+        return Path(home) / "state"
+    base = os.environ.get("XDG_STATE_HOME") or Path.home() / ".local" / "state"
+    return Path(base) / "phone-harness"
+
+
+def run_dir():
+    return state_dir() / "run"
+
+
+def paths():
+    return {"config": config_dir() / "config.json",
+            "devices": state_dir() / "devices.json",
+            "run": run_dir()}
+
+
+# --- files -------------------------------------------------------------------
+
+def _read(path, empty):
+    try:
+        data = json.loads(path.read_text())
+        if not isinstance(data, dict):
+            raise ValueError("not an object")
+        return data
+    except FileNotFoundError:
+        return dict(empty)
+    except (OSError, ValueError) as e:
+        print(f"phone-harness: ignoring unreadable {path} ({e}); using defaults",
+              file=sys.stderr)
+        return dict(empty)
+
+
+def _write(path, data):
+    """Atomic: a crash mid-write leaves the old file, not half a new one."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    data = {"version": VERSION, **{k: v for k, v in data.items() if k != "version"}}
+    fd, tmp = tempfile.mkstemp(dir=path.parent, prefix=path.name, suffix=".tmp")
+    with os.fdopen(fd, "w") as f:
+        json.dump(data, f, indent=2)
+        f.write("\n")
+    os.replace(tmp, path)
+
+
+def load():
+    return _read(paths()["config"], {})
+
+
+def save(data):
+    _write(paths()["config"], data)
+
+
+# --- settings ----------------------------------------------------------------
+
+def _dig(d, key):
+    for part in key.split("."):
+        if not isinstance(d, dict) or part not in d:
+            return None
+        d = d[part]
+    return d
+
+
+def _coerce(text, like):
+    """An env-var string, shaped like the default it overrides."""
+    if isinstance(like, bool):
+        return text.strip().lower() in ("1", "true", "yes", "on")
+    if isinstance(like, int):
+        try:
+            return int(text)
+        except ValueError:
+            return like
+    return text
+
+
+def _env_names(key):
+    return _ENV_ALIASES.get(key, []) + [
+        "PHONE_HARNESS_" + key.upper().replace(".", "_")]
+
+
+def lookup(key, default=None):
+    """(value, source) for a dotted key; source is 'env:NAME', 'file',
+    'default' or 'unset'."""
+    built_in = _dig(DEFAULTS, key)
+    for name in _env_names(key):
+        if name in os.environ:
+            return _coerce(os.environ[name], built_in), f"env:{name}"
+    v = _dig(load(), key)
+    if v is not None:
+        return v, "file"
+    if built_in is not None:
+        return built_in, "default"
+    return default, "unset"
+
+
+def get(key, default=None):
+    return lookup(key, default)[0]
+
+
+def set(key, value):
+    """Set a dotted key in config.json. Strings that look like JSON scalars
+    ('true', '25') become that value, so the CLI can pass text through."""
+    if isinstance(value, str):
+        try:
+            parsed = json.loads(value)
+            if isinstance(parsed, (bool, int, float)) or parsed is None:
+                value = parsed
+        except ValueError:
+            pass
+    data = load()
+    d = data
+    parts = key.split(".")
+    for part in parts[:-1]:
+        if not isinstance(d.get(part), dict):
+            d[part] = {}
+        d = d[part]
+    d[parts[-1]] = value
+    save(data)
+    return value
+
+
+def unset(key):
+    data = load()
+    d = data
+    parts = key.split(".")
+    for part in parts[:-1]:
+        d = d.get(part) if isinstance(d, dict) else None
+        if d is None:
+            return
+    d.pop(parts[-1], None)
+    save(data)
+
+
+def known_keys():
+    out = []
+    def walk(d, prefix=""):
+        for k, v in d.items():
+            if isinstance(v, dict):
+                walk(v, prefix + k + ".")
+            else:
+                out.append(prefix + k)
+    walk(DEFAULTS)
+    return out
+
+
+# --- devices (state) ---------------------------------------------------------
+
+def devices():
+    """The remembered-devices file, whole: {"version", "<kind>": {...}}.
+    Migrates the pre-config android.json once, if it is found."""
+    p = paths()["devices"]
+    data = _read(p, {})
+    if not data.get("android"):
+        legacy = config_dir() / "android.json"
+        if legacy.exists():
+            old = _read(legacy, {})
+            if old.get("phones") or old.get("primary"):
+                data["android"] = {"primary": old.get("primary"),
+                                   "phones": old.get("phones") or {}}
+                _write(p, data)
+                legacy.rename(legacy.with_suffix(".json.migrated"))
+    return data
+
+
+def devices_of(kind):
+    """The section for one backend, always shaped {"primary", "phones"}."""
+    sect = devices().get(kind) or {}
+    return {"primary": sect.get("primary"), "phones": sect.get("phones") or {}}
+
+
+def save_devices_of(kind, section):
+    data = devices()
+    data[kind] = {"primary": section.get("primary"),
+                  "phones": section.get("phones") or {}}
+    _write(paths()["devices"], data)
+
+
+# --- CLI (phone-harness config ...) -----------------------------------------
+
+CLI_USAGE = """Usage:
+  phone-harness config                 every setting, its value, and where it came from
+  phone-harness config get KEY
+  phone-harness config set KEY VALUE   e.g. config set platform android
+  phone-harness config unset KEY
+  phone-harness config path            where the files live
+"""
+
+
+def cli(args):
+    cmd = args[0] if args else None
+    if cmd is None:
+        for key in known_keys():
+            value, source = lookup(key)
+            print(f"{key:<22} {json.dumps(value):<10} ({source})")
+        for k, v in load().items():
+            if k != "version" and not isinstance(v, dict) and k not in known_keys():
+                print(f"{k:<22} {json.dumps(v):<10} (file, unknown key)")
+        return 0
+    if cmd == "get" and len(args) == 2:
+        value, source = lookup(args[1])
+        print(json.dumps(value) if source != "unset" else f"{args[1]}: unset")
+        return 0 if source != "unset" else 1
+    if cmd == "set" and len(args) == 3:
+        if args[1] == "platform" and args[2] not in ("ios", "android"):
+            print("platform must be ios or android"); return 2
+        v = set(args[1], args[2])
+        print(f"{args[1]} = {json.dumps(v)}")
+        return 0
+    if cmd == "unset" and len(args) == 2:
+        unset(args[1]); print(f"{args[1]} unset"); return 0
+    if cmd == "path":
+        for k, v in paths().items():
+            print(f"{k:<8} {v}")
+        return 0
+    print(CLI_USAGE)
+    return 2

--- a/src/phone_harness/helpers.py
+++ b/src/phone_harness/helpers.py
@@ -437,6 +437,33 @@ def wait(seconds=1.0):
     time.sleep(seconds)
 
 
+def wait_for_text(query, timeout=10.0, exact=False, interval=0.5):
+    """Poll until `query` is visible; -> its box or None. The verify step
+    after an action: wait for the thing you expect to appear rather than
+    sleeping and hoping. Cheap where the device has a tree, a capture+OCR
+    per poll where it doesn't."""
+    deadline = time.time() + timeout
+    while True:
+        hits = find_text(query, exact=exact)
+        if hits:
+            return hits[0]
+        if time.time() >= deadline:
+            return None
+        time.sleep(interval)
+
+
+def wait_for_app(app_id, timeout=10.0, interval=0.3):
+    """Poll until `app_id` is the foreground app; -> True/False. A ~0.1s check
+    on Android; Unsupported where the device exposes no foreground app."""
+    deadline = time.time() + timeout
+    while True:
+        if send("apps.current") == app_id:
+            return True
+        if time.time() >= deadline:
+            return False
+        time.sleep(interval)
+
+
 def wait_stable(timeout=6.0, interval=0.5, settle=2):
     """Wait until `settle` consecutive captures are identical (animation done).
     The status-bar clock ticks once a minute, so near-misses are rare."""

--- a/src/phone_harness/run.py
+++ b/src/phone_harness/run.py
@@ -10,6 +10,7 @@ USAGE = """Usage:
 Commands:
   phone-harness --doctor    diagnose permissions, app, and session state
   phone-harness skill       print the phone-harness skill text
+  phone-harness android ... pair/connect/choose an Android phone
 """
 
 
@@ -21,6 +22,9 @@ def main():
     if args and args[0] in {"--doctor", "doctor"}:
         from .admin import run_doctor
         sys.exit(run_doctor())
+    if args and args[0] == "android":
+        from .android import cli
+        sys.exit(cli(args[1:]))
     if args and args[0] == "skill":
         repo_root = Path(__file__).resolve().parent.parent.parent
         print((repo_root / "SKILL.md").read_text(encoding="utf-8"), end="")

--- a/src/phone_harness/run.py
+++ b/src/phone_harness/run.py
@@ -11,7 +11,7 @@ Commands:
   phone-harness --doctor    diagnose permissions, app, and session state
   phone-harness skill       print the phone-harness skill text
   phone-harness android ... pair/connect/choose an Android phone
-  phone-harness use ios|android   which phone helpers drive by default
+  phone-harness config ...  settings: `config set platform android`
 """
 
 
@@ -26,15 +26,9 @@ def main():
     if args and args[0] == "android":
         from .android import cli
         sys.exit(cli(args[1:]))
-    if args and args[0] == "use":
-        from . import transport
-        if len(args) < 2 or args[1] not in ("ios", "android"):
-            print(f"default platform: {transport.default_platform()}\n"
-                  "usage: phone-harness use ios|android")
-            sys.exit(0 if len(args) < 2 else 2)
-        transport.set_default_platform(args[1])
-        print(f"default platform: {args[1]}")
-        return
+    if args and args[0] == "config":
+        from .config import cli
+        sys.exit(cli(args[1:]))
     if args and args[0] == "skill":
         repo_root = Path(__file__).resolve().parent.parent.parent
         print((repo_root / "SKILL.md").read_text(encoding="utf-8"), end="")

--- a/src/phone_harness/run.py
+++ b/src/phone_harness/run.py
@@ -11,6 +11,7 @@ Commands:
   phone-harness --doctor    diagnose permissions, app, and session state
   phone-harness skill       print the phone-harness skill text
   phone-harness android ... pair/connect/choose an Android phone
+  phone-harness use ios|android   which phone helpers drive by default
 """
 
 
@@ -25,6 +26,15 @@ def main():
     if args and args[0] == "android":
         from .android import cli
         sys.exit(cli(args[1:]))
+    if args and args[0] == "use":
+        from . import transport
+        if len(args) < 2 or args[1] not in ("ios", "android"):
+            print(f"default platform: {transport.default_platform()}\n"
+                  "usage: phone-harness use ios|android")
+            sys.exit(0 if len(args) < 2 else 2)
+        transport.set_default_platform(args[1])
+        print(f"default platform: {args[1]}")
+        return
     if args and args[0] == "skill":
         repo_root = Path(__file__).resolve().parent.parent.parent
         print((repo_root / "SKILL.md").read_text(encoding="utf-8"), end="")

--- a/src/phone_harness/transport.py
+++ b/src/phone_harness/transport.py
@@ -67,7 +67,9 @@ Anything a backend genuinely cannot do raises Unsupported. Callers gate on
 supports(op) rather than guessing.
 """
 import importlib
+import json
 import os
+from pathlib import Path
 
 
 class Unsupported(RuntimeError):
@@ -119,15 +121,42 @@ class Backend:
         return [op for op in OP_NAMES if self.supports(op)]
 
 
+CONFIG_DIR = Path(os.environ.get("PHONE_HARNESS_CONFIG_DIR",
+                                 Path.home() / ".config" / "phone-harness"))
+
+
+def default_platform():
+    """The platform to use when nothing says otherwise: the one saved by
+    `phone-harness use <platform>`, else ios."""
+    try:
+        return json.loads((CONFIG_DIR / "config.json").read_text()).get(
+            "platform") or "ios"
+    except (OSError, ValueError):
+        return "ios"
+
+
+def set_default_platform(platform):
+    CONFIG_DIR.mkdir(parents=True, exist_ok=True)
+    path = CONFIG_DIR / "config.json"
+    try:
+        cfg = json.loads(path.read_text())
+    except (OSError, ValueError):
+        cfg = {}
+    cfg["platform"] = platform
+    path.write_text(json.dumps(cfg, indent=2) + "\n")
+
+
 def connect(platform=None, **kw):
-    """Build a backend. PHONE_HARNESS_PLATFORM selects one; default is ios.
+    """Build a backend. Explicit argument, else PHONE_HARNESS_PLATFORM, else
+    the default saved by `phone-harness use <platform>`, else ios.
 
     Returns an object rather than installing a module global, so a script can
     hold two devices at once instead of being limited to one per process.
     helpers.py binds one of these as its default.
     """
     platform = (platform
-                or os.environ.get("PHONE_HARNESS_PLATFORM", "ios")).lower()
+                or os.environ.get("PHONE_HARNESS_PLATFORM")
+                or default_platform()).lower()
     if platform in ("ios", "iphone", "ipad"):
         return importlib.import_module(".ios", __package__).IPhone(**kw)
     if platform == "android":

--- a/src/phone_harness/transport.py
+++ b/src/phone_harness/transport.py
@@ -67,9 +67,7 @@ Anything a backend genuinely cannot do raises Unsupported. Callers gate on
 supports(op) rather than guessing.
 """
 import importlib
-import json
 import os
-from pathlib import Path
 
 
 class Unsupported(RuntimeError):
@@ -121,42 +119,17 @@ class Backend:
         return [op for op in OP_NAMES if self.supports(op)]
 
 
-CONFIG_DIR = Path(os.environ.get("PHONE_HARNESS_CONFIG_DIR",
-                                 Path.home() / ".config" / "phone-harness"))
-
-
-def default_platform():
-    """The platform to use when nothing says otherwise: the one saved by
-    `phone-harness use <platform>`, else ios."""
-    try:
-        return json.loads((CONFIG_DIR / "config.json").read_text()).get(
-            "platform") or "ios"
-    except (OSError, ValueError):
-        return "ios"
-
-
-def set_default_platform(platform):
-    CONFIG_DIR.mkdir(parents=True, exist_ok=True)
-    path = CONFIG_DIR / "config.json"
-    try:
-        cfg = json.loads(path.read_text())
-    except (OSError, ValueError):
-        cfg = {}
-    cfg["platform"] = platform
-    path.write_text(json.dumps(cfg, indent=2) + "\n")
-
-
 def connect(platform=None, **kw):
     """Build a backend. Explicit argument, else PHONE_HARNESS_PLATFORM, else
-    the default saved by `phone-harness use <platform>`, else ios.
+    `platform` in the config file (`phone-harness config set platform …`),
+    else ios.
 
     Returns an object rather than installing a module global, so a script can
     hold two devices at once instead of being limited to one per process.
     helpers.py binds one of these as its default.
     """
-    platform = (platform
-                or os.environ.get("PHONE_HARNESS_PLATFORM")
-                or default_platform()).lower()
+    from . import config
+    platform = (platform or config.get("platform")).lower()
     if platform in ("ios", "iphone", "ipad"):
         return importlib.import_module(".ios", __package__).IPhone(**kw)
     if platform == "android":

--- a/src/phone_harness/transport.py
+++ b/src/phone_harness/transport.py
@@ -130,4 +130,6 @@ def connect(platform=None, **kw):
                 or os.environ.get("PHONE_HARNESS_PLATFORM", "ios")).lower()
     if platform in ("ios", "iphone", "ipad"):
         return importlib.import_module(".ios", __package__).IPhone(**kw)
+    if platform == "android":
+        return importlib.import_module(".android", __package__).Android(**kw)
     raise ValueError(f"unknown platform {platform!r}")


### PR DESCRIPTION
Stacked on #19 — the second device behind the `send()` seam, and the one that shows why the seam is worth having: `android.py` is one file, `transport.py` gains one line, and every helper an agent already knows works unchanged on a Pixel.

## What's in it

- **`android.py` — `Android(Backend)`, pure adb.** No agent app on the phone, no Appium, no OCR. `screencap` is the capture; `uiautomator dump` is the tree, so `screen.text` answers *exactly* (`source: "tree"`) where iOS has to recognise glyphs — and `tap_ui("url_bar")` finds things OCR never could. `input tap/swipe/keyevent/text` for hands; `nav.back` exists here; `apps.launch/current/list` via `pm`/`am`/`dumpsys`. adb reaches the device directly, so `focus.*` reports nothing disturbed and `session.refocus` is a no-op. Coordinates are device pixels: a screenshot is 1:1 with `tap(x, y)`. Chords raise `Unsupported` (adb keyevents are single keys); pixel OCR is not offered (the tree is the text source; a caller wanting pixels has `screen.capture`).
- **The phone finds itself.** `session.require` — which every helper passes through — resolves a device: a USB phone if plugged in, else a live wireless link (the saved primary first), else a paired phone found on the LAN over mDNS and `adb connect`ed on the spot, else a message naming the physical step that is missing. Paired phones are remembered in `~/.config/phone-harness/android.json` by friendly name and matched by hardware serial (mDNS announces `adb-<SERIAL>-…`), so a phone whose Wi‑Fi port changed overnight is still `pixel-8`. First phone paired over Wi‑Fi becomes the primary. `ANDROID_SERIAL` overrides everything.
- **`phone-harness android` CLI** (same shape as `cloud up/ls/down`): status · `pair CODE [NAME]` (finds the phone's pairing service over mDNS, pairs, then finds the *connect* port and connects — only the 6-digit code crosses; `pair IP:PORT CODE` if mDNS is blocked) · `connect [NAME|IP:PORT]` · `use NAME` · `forget NAME` · **`awake [--bg]`** · **`rest`**.
- **`locked` is a state.** adb happily taps a lock screen and dumps its PIN pad; nothing errors. So the backend asks (`dumpsys power/window`): `session.state` reports `locked`, wakes a dozing screen itself, and refuses input, app launches and the tree with a message that says unlock it — a PIN is never typed for the user. `screen.capture` stays free so the agent can show what it sees.
- **`awake` keeps the phone awake for a session without touching a setting.** A longer timeout or Developer-options Stay awake outlive the session — unplug mid-task and the phone is left changed. Instead a companion sends a keypress no app reacts to (`KEYCODE_UNKNOWN`) every 25s, which the phone counts as user activity; wired or Wi‑Fi, charging or not, it never reaches its timeout while this runs, and reverts the instant it stops. Pokes pause while locked. If scrcpy is installed the phone is mirrored in a window titled with its name; closing it ends the session. `rest` ends it and lets the phone sleep.
- **Two shared helpers** turn "did it work" into one line — act, then poll for the effect you expect: `wait_for_text(query)` → box or None; `wait_for_app(app_id)` → True/False (~0.1s per poll on Android).
- **SKILL.md** gains an Android section: how to select it, what's exact vs absent, verify cheaply then read, batch a sub-task per invocation (the tree costs seconds on a slow phone), the lock behaviour, and `awake`/`rest`.

## Verified

On a BLU G45 (Android 15) over USB, through the unmodified helpers via `run.py`'s stdin path: state/bounds/screenshot, tree text, `tap_text`, `tap_ui`, `find_nodes`, `type_text` (Settings search → "Bluetooth"), `scroll`/`scroll_screen`, `open_app`, `back`, `app_switcher`, `current_app`, `list_apps`, `wait_stable`. Two fresh agents driven only by SKILL.md onboarded the owner from a phone with no Developer options to Settings → Android version and Chrome → example.com. `locked` reported and screen woken; `ocr()`/`tap()` refused with the message; screenshot allowed. `awake --bg`: awake and unlocked through +151s on a 60s timeout, mirror titled `phone-harness: g45`; after `rest` the phone dozes and its settings read exactly as before. Registry, resolution order and mDNS connect covered with adb doubles.

**Wireless verified too:** on the same G45 over a phone hotspot — `phone-harness android pair CODE` found the phone over mDNS, paired and connected with only the 6-digit code, remembered it as `g45` (primary); helpers drove it over Wi‑Fi; after `adb disconnect` the first helper call found and reconnected it in under a second. Still unverified: the USB "Allow" prompt flow beyond what the `unauthorized` state handles.

## Known limits, stated as such

`input text` is ASCII only (adb's limitation). `uiautomator dump` costs ~2.5s on a slow phone; the skill tells the agent to batch. Both are honest floors of plain adb — a pushed on-device helper would lift them, and is deliberately not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)