### PR TITLE
release: 0.1.1 — the first version that installs from PyPI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,37 @@
+# Publish to PyPI on a version tag. Uses PyPI trusted publishing (OIDC): no
+# tokens stored anywhere — PyPI is told to trust this repo + workflow +
+# environment. First-time setup on pypi.org: Publishing -> add a pending
+# publisher for project "phone-harness", owner ShawnPana, repository
+# phone-harness, workflow publish.yml, environment pypi.
+name: publish
+
+on:
+  push:
+    tags: ["[0-9]*.[0-9]*.[0-9]*"]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with: { python-version: "3.12" }
+      - run: python -m pip install --upgrade build
+      - run: python -m build
+      - name: the tag must match pyproject's version
+        run: |
+          v=$(python -c 'import tomllib;print(tomllib.load(open("pyproject.toml","rb"))["project"]["version"])')
+          [ "$v" = "${GITHUB_REF_NAME}" ] || { echo "tag ${GITHUB_REF_NAME} != version $v"; exit 1; }
+      - uses: actions/upload-artifact@v4
+        with: { name: dist, path: dist/ }
+
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with: { name: dist, path: dist/ }
+      - uses: pypa/gh-action-pypi-publish@release/v1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,14 +1,30 @@
 [project]
 name = "phone-harness"
-version = "0.1.0"
+version = "0.1.1"
 description = "Control a real iPhone through macOS iPhone Mirroring: OCR eyes, CGEvent hands"
+readme = "README.md"
+license = "MIT"
+license-files = ["LICENSE"]
 requires-python = ">=3.10"
+keywords = ["iphone", "automation", "agent", "iphone-mirroring", "macos"]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Environment :: MacOS X",
+    "Operating System :: MacOS",
+    "Programming Language :: Python :: 3",
+    "Topic :: Software Development :: Testing",
+]
 dependencies = [
     "pyobjc-framework-Quartz",
     "pyobjc-framework-Vision",
-    "pyobjc-framework-AppKit",
+    "pyobjc-framework-Cocoa",
     "pyobjc-framework-ApplicationServices",
 ]
+
+[project.urls]
+Homepage = "https://phone-harness.com"
+Repository = "https://github.com/ShawnPana/phone-harness"
+Issues = "https://github.com/ShawnPana/phone-harness/issues"
 
 [project.scripts]
 phone-harness = "phone_harness.run:main"
@@ -19,3 +35,11 @@ build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/phone_harness"]
+
+# The skill text ships inside the package so `phone-harness skill` works
+# from an installed wheel, not only from a checkout.
+[tool.hatch.build.targets.wheel.force-include]
+"SKILL.md" = "phone_harness/SKILL.md"
+
+[tool.hatch.build.targets.sdist]
+include = ["src/phone_harness", "SKILL.md", "README.md", "LICENSE", "install.md"]

--- a/src/phone_harness/run.py
+++ b/src/phone_harness/run.py
@@ -13,6 +13,20 @@ Commands:
 """
 
 
+def _skill_text():
+    """SKILL.md: packaged alongside the code in a wheel; at the repo root in
+    a checkout (where the launcher runs the working tree)."""
+    from importlib import resources
+    try:
+        packaged = resources.files("phone_harness") / "SKILL.md"
+        if packaged.is_file():
+            return packaged.read_text(encoding="utf-8")
+    except (ImportError, OSError, TypeError):
+        pass
+    repo_root = Path(__file__).resolve().parent.parent.parent
+    return (repo_root / "SKILL.md").read_text(encoding="utf-8")
+
+
 def main():
     args = sys.argv[1:]
     if args and args[0] in {"-h", "--help"}:
@@ -22,8 +36,7 @@ def main():
         from .admin import run_doctor
         sys.exit(run_doctor())
     if args and args[0] == "skill":
-        repo_root = Path(__file__).resolve().parent.parent.parent
-        print((repo_root / "SKILL.md").read_text(encoding="utf-8"), end="")
+        print(_skill_text(), end="")
         return
     if args or sys.stdin.isatty():
         sys.exit(USAGE)


### PR DESCRIPTION
Publish-first, before the feature stack lands as 0.2.0.

`0.1.0` can't be published as tagged: it depends on `pyobjc-framework-AppKit`, which doesn't exist on PyPI (AppKit lives in `pyobjc-framework-Cocoa`), so every `pip install phone-harness` would fail — and PyPI releases are immutable. So PyPI starts at **0.1.1**: the 0.1.0 code plus only what a wheel needs.

## Changes
- `pyproject.toml`: `pyobjc-framework-Cocoa`; version 0.1.1; readme/license/URLs/keywords/classifiers; `SKILL.md` force-included into the package; sdist includes.
- `run.py`: `phone-harness skill` reads `SKILL.md` via `importlib.resources` (installed wheel) with fallback to the repo root (checkout). Previously it read `../../SKILL.md` relative to the package, which is wrong inside `site-packages`.
- `.github/workflows/publish.yml`: on a version tag, build sdist+wheel, assert the tag equals `pyproject`'s version, publish via **PyPI trusted publishing** (OIDC, environment `pypi`, no stored tokens).

## Verified
Built wheel installed into a fresh venv; dependencies resolved (`cocoa`, `quartz`, `vision`, `applicationservices`); `phone-harness --help` and `phone-harness skill` (102 lines) run from `site-packages`; `mirror`/`ocr`/`background`/`admin` import.

## To publish (one-time, on pypi.org)
Account → Publishing → **Add a new pending publisher**: PyPI project `phone-harness`, owner `ShawnPana`, repository `phone-harness`, workflow `publish.yml`, environment `pypi`. Then merge this and push tag `0.1.1`; the workflow does the rest. Every later release is a tag.

Note: the dependency line change is the same one #18 makes; both apply cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
