### PR TITLE
docs: onboarding for two phones — one question, then only the steps that need hands

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,12 +3,15 @@
 **[phone-harness](https://phone-harness.com)** · let your agent control your phone.
 
 Connect an AI agent — Claude Code, Codex, or any LLM — directly to your real
-iPhone with a thin, editable harness. No jailbreak, no Xcode, no WebDriverAgent.
+phone with a thin, editable harness. **iPhone** through the Mac's iPhone
+Mirroring window, or **Android** over adb (USB or Wi‑Fi). No jailbreak, no
+Xcode, no WebDriverAgent, no app on the phone.
 
-The Mac's iPhone Mirroring window is the whole transport: `screencapture` +
-Vision-framework OCR for eyes, HID-level CGEvents for hands. Nothing between the
-agent and the phone. The agent writes what's missing during execution in
-`agent-workspace/agent_helpers.py`.
+The Mac is the whole transport. iPhone: `screencapture` + Vision-framework OCR
+for eyes, HID-level CGEvents for hands. Android: `screencap` for eyes plus the
+phone's own accessibility tree — exact text, exact boxes — and `input` for
+hands. Nothing between the agent and the phone. The agent writes what's
+missing during execution in `agent-workspace/agent_helpers.py`.
 
 ```
   ● agent: wants to open Weather
@@ -26,47 +29,34 @@ agent and the phone. The agent writes what's missing during execution in
 Paste into Claude Code or Codex:
 
 ```text
-Set up phone-harness for me. Clone https://github.com/ShawnPana/phone-harness
-into ~/.phone-harness (its canonical home) and read `install.md` first to install
-it and connect it to my real iPhone
-through the macOS iPhone Mirroring app — install it so `phone-harness` is a
-command on my PATH, and register it as an agent skill named phone-harness using
-`phone-harness skill` as the body, so you reach for it automatically. Then read
-`SKILL.md` for normal usage, and always read `src/phone_harness/helpers.py`
-because that is where the functions are. Whenever you capture or verify the
-screen, activate the iPhone Mirroring window so I can see what you're doing on
-the phone.
+Set up phone-harness for me. Clone https://github.com/ShawnPana/phone-harness into ~/.phone-harness (its canonical home), read `install.md` first, install it so `phone-harness` is a command on my PATH, and register it as an agent skill named phone-harness using `phone-harness skill` as the body, so you reach for it automatically. Then read `SKILL.md` for normal usage, and always read `src/phone_harness/helpers.py` because that is where the functions are.
 
-Setup needs two things only I can do: pairing iPhone Mirroring with my phone
-once, and granting the terminal Accessibility + Screen Recording in System
-Settings — walk me through those and wait for me. Verify with
-`./phone-harness --doctor`.
+Ask me one question first: which phone should be my default — iPhone or Android? (I can set up both; then ask which is default.) Then do the setup for that phone, detecting what is already in place instead of asking me things you can check yourself; only stop for the steps that need my hands, and tell me exactly what to do on the phone or in System Settings.
 
-After it's installed, as a quick demo that interaction works, go to my Home
-Screen and — if the phone is connected and unlocked — ask me whether you should
-open github.com/ShawnPana/phone-harness on the phone and star the repo for me;
-only do it if I say yes. If the session is paused or the phone is locked, just
-tell me the doctor status instead.
+- iPhone: it works through the macOS iPhone Mirroring app. Two things only I can do: pair iPhone Mirroring with my phone once, and grant the terminal Accessibility + Screen Recording in System Settings — walk me through those and wait for me. Whenever you capture or verify the screen, bring the iPhone Mirroring window forward so I can see what you're doing.
+- Android: install Android platform-tools (adb) and scrcpy (optional live mirror). Ask whether I have a USB cable handy: with a cable, tell me how to turn on Developer options and USB debugging, then plug in and tap Allow; without one, Wireless debugging — I turn it on, open "Pair device with pairing code", and give you the 6-digit code for `phone-harness android pair CODE`. Then `phone-harness config set platform android` so it is my default.
+
+Verify with `phone-harness --doctor` (add `android` or `ios` to check the other phone). Then, as a quick read-only proof, take a screenshot and read the screen back to me. After that, ask me whether you should open phone-harness.com on the phone (Safari on iPhone, Chrome on Android), tap "Star on GitHub" and star the repo for me — only do it if I say yes. If the phone is locked or the session is paused, just tell me the doctor status instead.
 ```
 
-The agent will walk you through the two things only you can do: **pairing**
-iPhone Mirroring with your phone once (the pairing prompts need the physical
-phone), and granting the terminal **Accessibility** (taps & keystrokes) and
-**Screen Recording** (seeing the phone) in System Settings → Privacy &
-Security. Screen Recording takes effect after the terminal restarts;
-Accessibility is immediate. Then `./phone-harness --doctor` verifies the whole
-chain.
+The agent asks one thing — which phone is your default — and then walks you
+through only what needs your hands. **iPhone:** pairing iPhone Mirroring once,
+and granting the terminal **Accessibility** and **Screen Recording** in System
+Settings → Privacy & Security (Screen Recording takes effect after the terminal
+restarts). **Android:** turning on Developer options, then either plugging in
+and tapping Allow, or Wireless debugging + one 6‑digit pairing code. Then
+`phone-harness --doctor` verifies the chain, and `phone-harness config set
+platform ios|android` is how the default is set (both can be set up).
 
-These are the permissions currently known to be required. A fresh machine may
-prompt for more the first time an action runs — if `--doctor` passes but taps or
-capture silently do nothing, watch for a macOS permission prompt. See
-[install.md](install.md) for details.
+A fresh machine may prompt for more permissions the first time an action runs
+— if `--doctor` passes but taps or capture silently do nothing, watch for a
+macOS prompt. See [install.md](install.md) for details.
 
 ## Why this works
 
-iPhone Mirroring (macOS Sequoia+) renders the phone as a Mac window and forwards
-real mouse and keyboard input as touches. That gives an agent everything it
-needs for real-device iOS automation:
+**iPhone.** iPhone Mirroring (macOS Sequoia+) renders the phone as a Mac window
+and forwards real mouse and keyboard input as touches. That gives an agent
+everything it needs for real-device iOS automation:
 
 - **See** — capture just the mirroring window, OCR it with Apple's Vision
   framework: every visible string with a tap-ready coordinate. The poor man's
@@ -81,6 +71,16 @@ ignored — the window is a video stream with no accessibility tree), unicode ke
 payloads (mirroring forwards raw HID keycodes, so typing must use keycodes), a
 slow touch-drag (barely moves an iOS list — use wheel scroll for lists, a fast
 flick for pages), and input while the window isn't frontmost (swallowed).
+
+**Android.** adb reaches the phone directly, over USB or Wi‑Fi — no window, no
+focus, nothing on the Mac has to be in front. `screencap` is the capture; the
+phone's own accessibility tree (`uiautomator`) is the text source, so `ocr()`
+returns exact strings and boxes and `tap_ui("url_bar")` finds elements OCR
+never could; `input tap/swipe/text` are the hands; Back exists. Coordinates
+are device pixels, so a screenshot is 1:1 with `tap(x, y)`. The harness finds
+the phone itself (a plugged-in one first, else the paired Wi‑Fi phone),
+refuses to drive a locked one, and can keep it awake for a session without
+touching a setting. Same helpers, same agent code.
 
 ## Usage
 
@@ -101,17 +101,23 @@ reaches for it on its own.
 
 - `SKILL.md` — day-to-day usage (the agent-facing product surface)
 - `install.md` — permissions bootstrap and troubleshooting
-- `src/phone_harness/` — protected core (~500 lines):
-  - `mirror.py` — window discovery, focus, capture, CGEvent input
-  - `ocr.py` — Vision-framework text recognition → screen-point boxes
-  - `helpers.py` — the primitives pre-imported into scripts
-  - `admin.py` — `--doctor`
-  - `run.py` — the CLI (`exec` stdin with helpers in scope)
+- `src/phone_harness/` — protected core:
+  - `transport.py` — the one seam: the op vocabulary every device sits behind,
+    and `connect("ios"|"android")`
+  - `helpers.py` — the primitives pre-imported into scripts (platform-agnostic)
+  - `ios.py`, `mirror.py`, `background.py`, `ocr.py` — the iPhone: window
+    discovery, focus, capture, CGEvent input, Vision OCR
+  - `android.py` — the Android: adb, the accessibility tree, USB/Wi‑Fi
+    resolution and pairing, awake sessions, the `android` CLI
+  - `config.py` — settings (`phone-harness config`) and remembered devices
+  - `admin.py` — `--doctor`; `run.py` — the CLI (`exec` stdin with helpers in scope)
 - `agent-workspace/agent_helpers.py` — helper code the agent edits; auto-loaded
   into every script's namespace
 
-The mirror transport is stateless (window bounds and captures are re-queried per
-call), so there is no daemon — every invocation is self-contained.
+Both transports are stateless per call (window bounds and captures are
+re-queried; adb has its own server), so there is no daemon — every invocation
+is self-contained. State that must persist (the default platform, paired
+Android phones) lives in `~/.config/phone-harness` and `~/.local/state/phone-harness`.
 
 ## Development
 
@@ -125,7 +131,11 @@ PY
 
 ## Limits
 
-- One phone, one session; unlocking the physical phone pauses mirroring.
-- No multi-touch (no pinch), no camera/Face ID flows, DRM video renders black.
-- OCR sees text, not semantics — unlabeled icons need a screenshot + a
+- iPhone: one phone, one session; unlocking the physical phone pauses mirroring.
+  OCR sees text, not semantics — unlabeled icons need a screenshot + a
   vision-capable model.
+- Android: the tree costs seconds on a slow phone and is unavailable on screens
+  that never go idle (read the screenshot instead); `input text` is ASCII;
+  key chords are not a thing over adb; a PIN-locked phone needs the user.
+- Both: no multi-touch (no pinch), no camera/Face ID flows, DRM video renders
+  black. Connecting the phone is always the user's job.

--- a/README.md
+++ b/README.md
@@ -29,24 +29,18 @@ missing during execution in `agent-workspace/agent_helpers.py`.
 Paste into Claude Code or Codex:
 
 ```text
-Set up phone-harness for me. Clone https://github.com/ShawnPana/phone-harness into ~/.phone-harness (its canonical home), read `install.md` first, install it so `phone-harness` is a command on my PATH, and register it as an agent skill named phone-harness using `phone-harness skill` as the body, so you reach for it automatically. Then read `SKILL.md` for normal usage, and always read `src/phone_harness/helpers.py` because that is where the functions are.
-
-Ask me one question first: which phone should be my default — iPhone or Android? (I can set up both; then ask which is default.) Then do the setup for that phone, detecting what is already in place instead of asking me things you can check yourself; only stop for the steps that need my hands, and tell me exactly what to do on the phone or in System Settings.
-
-- iPhone: it works through the macOS iPhone Mirroring app. Two things only I can do: pair iPhone Mirroring with my phone once, and grant the terminal Accessibility + Screen Recording in System Settings — walk me through those and wait for me. Whenever you capture or verify the screen, bring the iPhone Mirroring window forward so I can see what you're doing.
-- Android: install Android platform-tools (adb) and scrcpy (optional live mirror). Ask whether I have a USB cable handy: with a cable, tell me how to turn on Developer options and USB debugging, then plug in and tap Allow; without one, Wireless debugging — I turn it on, open "Pair device with pairing code", and give you the 6-digit code for `phone-harness android pair CODE`. Then `phone-harness config set platform android` so it is my default.
-
-Verify with `phone-harness --doctor` (add `android` or `ios` to check the other phone). Then, as a quick read-only proof, take a screenshot and read the screen back to me. After that, ask me whether you should open phone-harness.com on the phone (Safari on iPhone, Chrome on Android), tap "Star on GitHub" and star the repo for me — only do it if I say yes. If the phone is locked or the session is paused, just tell me the doctor status instead.
+Set up phone-harness for me. Clone https://github.com/ShawnPana/phone-harness into ~/.phone-harness (its canonical home), read `install.md` first, install it so `phone-harness` is a command on my PATH, and register it as an agent skill named phone-harness using `phone-harness skill` as the body, so you reach for it automatically. Then read `SKILL.md` for normal usage, and always read `src/phone_harness/helpers.py` because that is where the functions are. Then read `onboarding.md` and walk me through it.
 ```
 
-The agent asks one thing — which phone is your default — and then walks you
-through only what needs your hands. **iPhone:** pairing iPhone Mirroring once,
-and granting the terminal **Accessibility** and **Screen Recording** in System
-Settings → Privacy & Security (Screen Recording takes effect after the terminal
-restarts). **Android:** turning on Developer options, then either plugging in
-and tapping Allow, or Wireless debugging + one 6‑digit pairing code. Then
+The agent then follows [onboarding.md](onboarding.md): it asks one thing —
+which phone is your default, iPhone or Android — and walks you through only
+what needs your hands. **iPhone:** pairing iPhone Mirroring once, and granting
+the terminal **Accessibility** and **Screen Recording** in System Settings →
+Privacy & Security (Screen Recording takes effect after the terminal restarts).
+**Android:** turning on Developer options, then either plugging in and tapping
+Allow, or Wireless debugging + one 6‑digit pairing code. Then
 `phone-harness --doctor` verifies the chain, and `phone-harness config set
-platform ios|android` is how the default is set (both can be set up).
+platform ios|android` sets the default (both can be set up).
 
 A fresh machine may prompt for more permissions the first time an action runs
 — if `--doctor` passes but taps or capture silently do nothing, watch for a
@@ -100,7 +94,8 @@ reaches for it on its own.
 ## Architecture
 
 - `SKILL.md` — day-to-day usage (the agent-facing product surface)
-- `install.md` — permissions bootstrap and troubleshooting
+- `onboarding.md` — the first-run flow the agent walks the user through
+- `install.md` — setup reference and troubleshooting
 - `src/phone_harness/` — protected core:
   - `transport.py` — the one seam: the op vocabulary every device sits behind,
     and `connect("ios"|"android")`

--- a/SKILL.md
+++ b/SKILL.md
@@ -5,8 +5,11 @@ description: "Control the user's phone — iPhone through the Mac's iPhone Mirro
 
 # phone-harness
 
-Direct iPhone control via the iPhone Mirroring app — screenshots + Vision OCR
-for eyes, HID-level CGEvents for hands. For task-specific edits, use
+Direct control of the user's phone. iPhone: through the iPhone Mirroring app —
+screenshots + Vision OCR for eyes, HID-level CGEvents for hands. Android: over
+adb — screenshots + the phone's accessibility tree for eyes, `input` for hands
+(see the Android section; the helpers are the same). `phone-harness config`
+shows which is the default. For task-specific edits, use
 `agent-workspace/agent_helpers.py`. For setup or permission problems, read
 `install.md`.
 

--- a/install.md
+++ b/install.md
@@ -1,6 +1,7 @@
 # phone-harness install
 
-phone-harness drives a real phone from a Mac: an **iPhone** through the macOS
+phone-harness drives a real phone from a Mac (first-run flow for agents:
+`onboarding.md`; day-to-day usage: `SKILL.md`). It works with an **iPhone** through the macOS
 iPhone Mirroring app, or an **Android** over adb (USB or Wi‑Fi). Same helpers
 either way; you choose a default and can switch per call.
 

--- a/install.md
+++ b/install.md
@@ -1,93 +1,98 @@
 # phone-harness install
 
-Use once. For phone work, read `SKILL.md`.
+phone-harness drives a real phone from a Mac: an **iPhone** through the macOS
+iPhone Mirroring app, or an **Android** over adb (USB or Wi‑Fi). Same helpers
+either way; you choose a default and can switch per call.
 
-## Requirements
-
-- macOS Sequoia+ with iPhone Mirroring paired to the phone (open the app once
-  manually to pair — pairing prompts need the physical phone).
-- Python 3.12+ with pyobjc (`pip install pyobjc-framework-Quartz
-  pyobjc-framework-Vision pyobjc-framework-Cocoa`).
-- The terminal app needs two permissions in System Settings > Privacy &
-  Security. **The toggles require the user:**
-  - **Accessibility** — taps and keystrokes. Takes effect immediately.
-  - **Screen Recording** — seeing the phone. Takes effect after the terminal
-    app restarts.
-
-Open the panes directly:
-
-```bash
-open "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility"
-open "x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenCapture"
-```
-
-> **Heads up — you may need to grant more than these two.** Accessibility and
-> Screen Recording are the permissions we *know* are required, and they're all
-> `--doctor` currently checks. But this was built on a machine that was already
-> permissive, so a fresh Mac may prompt for additional approvals the first time
-> an action runs. If `--doctor` passes but taps, typing, or capture silently do
-> nothing, watch for a macOS permission prompt and check System Settings >
-> Privacy & Security for a pane asking to approve your terminal. As we pin down
-> exactly which extra permissions a clean install needs, they'll get added to
-> `--doctor` as proper prerequisites.
-
-## Fast Path
+## Common
 
 ```bash
 git clone https://github.com/ShawnPana/phone-harness ~/.phone-harness   # canonical home
 cd ~/.phone-harness
-pip install pyobjc-framework-Quartz pyobjc-framework-Vision pyobjc-framework-Cocoa
-pip install -e . --no-deps            # installs the global `phone-harness` command
+pip install -e .                      # the global `phone-harness` command (pulls pyobjc)
 
-# register as an agent skill so Claude Code / Codex auto-use it (see below)
+# register as an agent skill so Claude Code / Codex reach for it automatically
 mkdir -p ~/.claude/skills/phone-harness
 phone-harness skill > ~/.claude/skills/phone-harness/SKILL.md
 mkdir -p "${CODEX_HOME:-$HOME/.codex}/skills/phone-harness"
 phone-harness skill > "${CODEX_HOME:-$HOME/.codex}/skills/phone-harness/SKILL.md"
-
-phone-harness --doctor
-phone-harness <<'PY'
-print(screen_info())
-PY
 ```
 
-If `screen_info()` prints window bounds, you're done.
+- Python 3.10+. Only the CLI? `pip install phone-harness` works too; the
+  checkout is what makes the harness editable (`agent-workspace/agent_helpers.py`).
+- The default phone is `phone-harness config set platform ios|android`;
+  `phone-harness config` shows every setting and where it came from;
+  `PHONE_HARNESS_PLATFORM=android phone-harness …` overrides for one call.
+- `phone-harness --doctor` checks the default phone; `--doctor ios` or
+  `--doctor android` checks the other.
 
-`~/.phone-harness` is the canonical home — a hidden folder in your home
-directory (like `~/.oh-my-zsh` or `~/.nvm`), so the code, `helpers.py`,
-`SKILL.md`, and your `agent-workspace/` always live at a path the agent knows,
-on any machine. `pip install -e .` keeps that source editable while giving you a
-`phone-harness` command on PATH, which is what lets the skill call
-`phone-harness` from any directory. Because the install is editable it's bound
-to that location, so keep the folder at `~/.phone-harness` (or re-run `pip
-install -e .` if you relocate it). If your Python can't reach PyPI to resolve the
-pyobjc deps, `--no-deps` skips them (they're installed by the line above).
+Re-run the `phone-harness skill > …/SKILL.md` lines after pulling updates so
+the agent's copy matches the code.
 
-## Register as a skill
+## iPhone
 
-So the agent reaches for phone-harness on its own, register `SKILL.md` as a
-skill named `phone-harness` with `phone-harness skill` as its body (the Fast
-Path does this for both Claude Code and Codex). The skill's trigger is:
+- macOS Sequoia+ with **iPhone Mirroring** paired to the phone (open the app
+  once and finish its pairing prompts — this needs the physical phone).
+- Two permissions for your **terminal**, in System Settings → Privacy & Security:
+  - **Accessibility** — taps and keystrokes. Takes effect immediately.
+  - **Screen Recording** — seeing the phone. Takes effect after the terminal
+    restarts.
+  ```bash
+  open "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility"
+  open "x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenCapture"
+  ```
+- Then `phone-harness --doctor ios`.
 
-```text
-Control the user's iPhone through the Mac's iPhone Mirroring window: open apps,
-tap, type, swipe, read the screen.
-```
+> You may need to grant more than these two. They are the permissions we
+> *know* are required and all `--doctor` checks; a fresh machine may prompt for
+> more the first time an action runs. If `--doctor` passes but taps, typing, or
+> capture silently do nothing, look for a macOS permission prompt.
 
-Re-run the `phone-harness skill > …/SKILL.md` lines after pulling updates so the
-registered copy stays current.
+## Android
+
+- `brew install android-platform-tools` (adb). Optional: `brew install scrcpy`
+  for a live mirror window during `phone-harness android awake`.
+- On the phone, once: Settings → About phone → tap **Build number** 7× →
+  Settings → System → **Developer options**.
+- **USB**: Developer options → **USB debugging** on → plug in → tap **Allow**
+  (tick "Always allow from this computer"). Done.
+- **Wi‑Fi** (Android 11+, same network as the Mac): Developer options →
+  **Wireless debugging** on → tap the row → **Pair device with pairing code** →
+  `phone-harness android pair 123456` with the code shown. The phone is
+  remembered by name; from then on the harness finds and connects it itself.
+- `phone-harness config set platform android` to make it the default, then
+  `phone-harness --doctor android`.
+- `phone-harness android` shows known phones and what is attached; a plugged-in
+  phone always wins over Wi‑Fi. Long task? `phone-harness android awake --bg`
+  keeps the phone unlocked for the session without changing any setting;
+  `phone-harness android rest` ends it.
+
+## Both
+
+Set up each as above; `phone-harness config set platform …` picks the default,
+`PHONE_HARNESS_PLATFORM=…` picks per call. The two never interfere — the
+iPhone is driven through the mirroring window, the Android over adb.
 
 ## If It Fails
 
-`--doctor` walks the ladder in order: pyobjc → Accessibility → Screen
-Recording → app installed → app running → window found → capture works → OCR
-works. Fix the first FAIL; later checks depend on earlier ones.
+`--doctor` walks the ladder in order and names the missing step. Common ones:
 
-Common cases:
-
-- **Capture is blank/black**: Screen Recording was granted but the terminal
-  hasn't restarted since.
-- **Window not found**: the phone isn't paired, isn't in range, or iPhone
-  Mirroring shows a connect screen — open the app manually once.
-- **Taps do nothing**: Accessibility missing, or another window stole focus —
-  events land only when the mirroring window is frontmost.
+- **iPhone — capture is blank/black**: Screen Recording granted but the
+  terminal wasn't restarted; or Mirroring shows an interstitial (iPhone in Use /
+  Connect / Mac Locked) — clear it on the Mac, lock the iPhone if it says in use.
+- **iPhone — taps do nothing**: Accessibility missing, or another window stole
+  focus (helpers re-activate the window; check for a macOS prompt).
+- **iPhone — `--doctor` says pyobjc missing on an install that works**: it is
+  running a different Python than the one that has pyobjc; use the interpreter
+  `pip install -e .` used, or `pip install pyobjc-framework-Quartz
+  pyobjc-framework-Vision pyobjc-framework-Cocoa` for that one.
+- **Android — `unauthorized`**: unlock the phone and tap Allow on the "Allow
+  USB debugging?" prompt (replug if it does not appear).
+- **Android — `no-device`**: USB debugging off, cable/port, or for Wi‑Fi:
+  Wireless debugging turned itself off (it does after a reboot) or a different
+  network than the Mac. `adb devices` shows what adb sees.
+- **Android — `locked`**: unlock the phone; `phone-harness android awake` keeps
+  it awake for the session. The harness never types a PIN.
+- **Android — the tree is unavailable on some screen**: that screen never goes
+  idle (something animates), so `uiautomator` refuses; read `screenshot()`
+  instead or move to a screen that settles.

--- a/onboarding.md
+++ b/onboarding.md
@@ -1,0 +1,59 @@
+# Onboarding
+
+You are setting up phone-harness with the user, once. Ask as little as
+possible: detect what is already in place, and stop only for the steps that
+need the user's hands. Tell them exactly what to do on the phone or in System
+Settings, then wait.
+
+## 1. One question
+
+"Which phone should be your default — iPhone or Android?" (Both is fine: set
+up each, then ask which is the default.)
+
+## 2. iPhone
+
+Works through the macOS iPhone Mirroring app. Two things only the user can do:
+
+- Pair iPhone Mirroring with the phone once (open the app; the pairing prompts
+  need the physical phone).
+- Grant the terminal **Accessibility** and **Screen Recording** in System
+  Settings → Privacy & Security (Screen Recording takes effect after the
+  terminal restarts).
+
+Check first — `phone-harness --doctor ios` — and only ask for what is missing.
+Whenever you capture or verify the screen, bring the Mirroring window forward
+so the user can see what you're doing.
+
+## 3. Android
+
+- Install adb (`brew install android-platform-tools`) and, optionally, scrcpy
+  (`brew install scrcpy`) for a live mirror during long tasks.
+- Ask whether they have a USB cable handy.
+  - **USB:** Developer options (Settings → About phone → tap Build number 7×)
+    → USB debugging → plug in → tap Allow ("Always allow from this computer").
+  - **Wi‑Fi:** Developer options → Wireless debugging (on; same Wi‑Fi as the
+    Mac) → tap the row → "Pair device with pairing code" → they read you the
+    6 digits → `phone-harness android pair CODE`.
+- `phone-harness config set platform android` if it is the default.
+
+Check with `phone-harness android` and `phone-harness --doctor android`.
+
+## 4. Verify
+
+`phone-harness --doctor` for the default phone (add `ios` or `android` to
+check the other), then a read-only proof: take a screenshot and read the
+screen back to the user.
+
+## 5. Demo (opt-in)
+
+Ask whether to open phone-harness.com on the phone (Safari on iPhone, Chrome
+on Android), tap "Star on GitHub" and star the repo for them — only if they say
+yes. If the phone is locked or the session is paused, report the doctor status
+instead.
+
+## Rules
+
+Never type a PIN. Never change a phone setting without asking. Connecting the
+phone is the user's job — relay the doctor's message and wait; don't
+retry-loop. After this, day-to-day usage is `SKILL.md`; setup reference and
+troubleshooting are `install.md`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,4 +42,4 @@ packages = ["src/phone_harness"]
 "SKILL.md" = "phone_harness/SKILL.md"
 
 [tool.hatch.build.targets.sdist]
-include = ["src/phone_harness", "SKILL.md", "README.md", "LICENSE", "install.md"]
+include = ["src/phone_harness", "SKILL.md", "onboarding.md", "README.md", "LICENSE", "install.md"]


### PR DESCRIPTION
Stacked on #43 (it references the platform-aware `--doctor`). Docs only.

## The onboarding flow
The setup prompt — README, and byte-identical on phone-harness.com (website commit ready to push after this lands) — now:
1. installs and registers the skill as before;
2. asks **one question**: which phone is the default, iPhone or Android (both possible; then which is default);
3. has the agent **detect** what's already in place rather than ask, stopping only for the steps that need hands — **iPhone:** pair Mirroring once, grant Accessibility + Screen Recording; **Android:** Developer options, then USB → tap Allow, or Wireless debugging → one 6-digit code (`phone-harness android pair CODE`), then `phone-harness config set platform android`;
4. verifies with `phone-harness --doctor` (+ `android`/`ios` for the other), then a read-only screenshot, then the opt-in "star the repo" demo adapted per platform.

## Files
- **install.md** — rewritten: Common (clone/pip, skill registration, `config set platform`, `--doctor`), iPhone, Android (adb, optional scrcpy, USB vs Wi‑Fi, `android pair`, `awake`/`rest`), Both, If It Fails (Android states `unauthorized`/`no-device`/`locked`/never-idle tree added).
- **README.md** — intro and "Why this works" cover both transports; Architecture lists `transport.py`/`ios.py`/`android.py`/`config.py`; Limits split per platform; new prompt + explanation.
- **SKILL.md** — platform-neutral opening; points at `phone-harness config`.

No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
