### PR TITLE
docs: clarify screenshot coordinate tapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,10 @@ everything it needs for real-device iOS automation:
   DOM.
 - **Act** — CGEvents posted at the HID tap: taps, long-presses, drags/flicks,
   scroll gestures, unicode typing, and the app's own shortcuts (Cmd+1 Home,
-  Cmd+2 App Switcher, Cmd+3 Spotlight).
+  Cmd+2 App Switcher, Cmd+3 Spotlight). For icon-only controls found in a
+  screenshot, use `tap_image_point(x, y, image_size=...)`: screenshot coordinates
+  are image pixels, while `tap(x, y)` expects global Mac screen points.
+  `image_point()` performs the conversion when a raw `tap()` is needed.
 - **Verify** — screenshot again. No DOM means the capture is the ground truth.
 
 Things that do NOT work, learned the hard way: AppleScript `click at` (silently

--- a/SKILL.md
+++ b/SKILL.md
@@ -43,9 +43,12 @@ PY
   in Python before printing.
 - Tap by label: `tap_text("Weather")`. On failure it raises with what IS
   visible, so read the exception before retrying.
-- Icons without labels: `screenshot()`, view the image, compute the point
-  (image px ÷ scale + window origin — `screen_info()` has both sizes), then
-  `tap(x, y)`.
+- Icons without labels: `screenshot()`, view the image, and use
+  `tap_image_point(x, y, image_size=...)` with coordinates measured in the
+  screenshot. Do **not** pass screenshot pixel coordinates directly to `tap()`:
+  `tap()` expects global macOS screen points. If using `tap()` instead, first
+  convert with `image_point()` using the current `screen_info()`; never estimate
+  the window offset manually.
 - **Verify after every action**: `wait_stable()` then `ocr()`/`screenshot()`.
   There is no DOM to assert against; the capture is the ground truth.
 - Navigation: `home()`, `app_switcher()`, `open_app("Notes")` (Spotlight),


### PR DESCRIPTION
## Summary
- document that screenshot coordinates are image pixels
- direct agents to use `tap_image_point()` for screenshot-derived taps
- explain conversion through `image_point()` when raw `tap()` is needed

## Validation
- `git diff --check`
- editable package reinstall
- verified `phone-harness skill` output