### PR TITLE
android: connect starts the awake session (mirror + keep-awake)

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -107,15 +107,20 @@ PY
 - **The phone locks itself** after its screen timeout. `connection_state()`
   reports `locked`; taps and `ocr()` refuse with the same message. Ask the
   user to unlock — never type a PIN. `screenshot()` still works locked, so you
-  can show them what you see. For a task longer than a minute, ask the user,
-  then run `phone-harness android awake --bg`: it keeps the phone awake for
-  the session (and opens a mirror window if scrcpy is installed) without
-  changing any phone setting; `phone-harness android rest` ends it and lets
-  the phone sleep. Do that at the end of the task.
+  can show them what you see. `phone-harness android awake --bg` keeps the
+  phone awake for the session (and opens a mirror window if scrcpy is
+  installed) without changing any phone setting; `phone-harness android
+  connect` starts it for you, so usually it is already running. `phone-harness
+  android rest` ends it and lets the phone sleep. Do that at the end of the task.
 - Connection is still the user's job (USB debugging + Allow, or Wireless
   debugging + `phone-harness android pair CODE`); on `no-device` the
   error names the missing step — relay it, don't retry-loop.
   `phone-harness android` shows known phones and what is attached.
+- **Connecting = seeing.** `phone-harness android connect` (a paired Wi‑Fi
+  phone, by name or IP:PORT) also starts the awake session in the background:
+  a scrcpy mirror window on the Mac plus keep-awake. That is the default
+  because the user wants the phone visible whenever it is connected;
+  `--no-awake` connects only, `--no-mirror` keeps awake without a window.
 
 ## Consent
 

--- a/install.md
+++ b/install.md
@@ -64,9 +64,12 @@ the agent's copy matches the code.
 - `phone-harness config set platform android` to make it the default, then
   `phone-harness --doctor android`.
 - `phone-harness android` shows known phones and what is attached; a plugged-in
-  phone always wins over Wi‑Fi. Long task? `phone-harness android awake --bg`
-  keeps the phone unlocked for the session without changing any setting;
-  `phone-harness android rest` ends it.
+  phone always wins over Wi‑Fi. `phone-harness android connect` connects the
+  primary phone over Wi‑Fi and starts the awake session — a scrcpy mirror
+  window plus keep-awake, no phone setting changed (`--no-awake` to skip,
+  `--no-mirror` for no window). `phone-harness android awake --bg` starts the
+  same session by hand (e.g. for a USB phone); `phone-harness android rest`
+  ends it.
 
 ## Both
 

--- a/src/phone_harness/android.py
+++ b/src/phone_harness/android.py
@@ -522,8 +522,12 @@ CLI_USAGE = """Usage:
   phone-harness android                          known phones, primary, what's live
   phone-harness android pair [CODE] [NAME]       Wireless debugging: pair with the 6-digit
                                                  code (phone found over mDNS), connect, remember
+                                                 (then starts the awake session like connect)
   phone-harness android pair IP:PORT CODE [NAME] the same, if mDNS is blocked on your network
-  phone-harness android connect [NAME|IP:PORT]   connect a paired phone (default: primary, via mDNS)
+  phone-harness android connect [NAME|IP:PORT] [--no-awake] [--no-mirror]
+        connect a paired phone (default: primary, via mDNS) and start the awake
+        session — mirror window + keep-awake — in the background. --no-awake
+        connects only; --no-mirror keeps awake without a window.
   phone-harness android use NAME                 make NAME the primary
   phone-harness android forget NAME
   phone-harness android awake [--bg] [--no-mirror]
@@ -621,6 +625,29 @@ def _awake(mirror=True):
             pass
 
 
+def _start_awake_bg(mirror=True):
+    """Detach an awake session (keep-awake pokes + scrcpy mirror if `mirror`
+    and scrcpy is installed). No-op if one is already running. Returns 0 on
+    success, 1 if the child died at once."""
+    pid = _awake_pid()
+    if pid:
+        print(f"already awake (pid {pid}); phone-harness android rest to end")
+        return 0
+    child = subprocess.Popen(
+        [sys.executable, "-m", "phone_harness.run", "android", "awake",
+         "--fg"] + (["--no-mirror"] if not mirror else []),
+        stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+        start_new_session=True)
+    _pidfile().parent.mkdir(parents=True, exist_ok=True)
+    _pidfile().write_text(str(child.pid))
+    time.sleep(2)
+    if child.poll() is None:
+        print(f"awake in background (pid {child.pid}); phone-harness android rest to end")
+        return 0
+    print("awake exited at once — is a phone connected? try: phone-harness android awake")
+    return 1
+
+
 def _awake_pid():
     """pid of a running awake session (not ourselves), else None."""
     try:
@@ -670,22 +697,12 @@ def cli(args):
         return 0
 
     if cmd == "awake":
+        mirror = "--no-mirror" not in args and bool(config.get("android.mirror"))
+        if "--bg" in args:
+            return _start_awake_bg(mirror=mirror)
         if _awake_pid():
             print(f"already awake (pid {_awake_pid()}); phone-harness android rest to end")
             return 0
-        mirror = "--no-mirror" not in args and bool(config.get("android.mirror"))
-        if "--bg" in args:
-            child = subprocess.Popen(
-                [sys.executable, "-m", "phone_harness.run", "android", "awake",
-                 "--fg"] + (["--no-mirror"] if not mirror else []),
-                stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
-                start_new_session=True)
-            _pidfile().parent.mkdir(parents=True, exist_ok=True)
-            _pidfile().write_text(str(child.pid))
-            time.sleep(2)
-            print(f"awake in background (pid {child.pid}); phone-harness android rest to end"
-                  if child.poll() is None else "awake exited at once — is a phone connected? try without --bg")
-            return 0 if child.poll() is None else 1
         _pidfile().parent.mkdir(parents=True, exist_ok=True)
         _pidfile().write_text(str(os.getpid()))
         return _awake(mirror=mirror)
@@ -767,25 +784,37 @@ def cli(args):
         if config.get("platform") != "android":
             print("tip: `phone-harness config set platform android` makes Android "
                   "the default, so nothing needs PHONE_HARNESS_PLATFORM=android")
+        if "--no-awake" not in args:
+            _start_awake_bg(mirror="--no-mirror" not in args
+                            and bool(config.get("android.mirror")))
         return 0
 
     if cmd == "connect":
-        target = args[1] if len(args) > 1 else cfg.get("primary")
+        flags = {a for a in args[1:] if a.startswith("--")}
+        pos = [a for a in args[1:] if not a.startswith("--")]
+        target = pos[0] if pos else cfg.get("primary")
         if not target:
             print("no primary phone yet — pair one first"); return 1
         if ":" in target:
             out = _run("connect", target, timeout=15, check=False); print(out.strip())
-            return 0 if "connected" in out and "cannot" not in out else 1
-        p = phones.get(target)
-        if not p:
-            print(f"unknown phone {target!r}; known: {', '.join(phones) or 'none'}"); return 1
-        adb_id = _connect_serial(p["serial"])
-        if adb_id is None:
-            print(f"'{target}' isn't announcing on this Wi-Fi. Is Wireless "
-                  "debugging on, and the phone on the same network?"); return 1
-        _remember(cfg, p["serial"], p.get("model"), host=adb_id.rpartition(":")[0],
-                  primary=True)
-        print(f"connected: {target} ({adb_id})"); return 0
+            if not ("connected" in out and "cannot" not in out):
+                return 1
+        else:
+            p = phones.get(target)
+            if not p:
+                print(f"unknown phone {target!r}; known: {', '.join(phones) or 'none'}"); return 1
+            adb_id = _connect_serial(p["serial"])
+            if adb_id is None:
+                print(f"'{target}' isn't announcing on this Wi-Fi. Is Wireless "
+                      "debugging on, and the phone on the same network?"); return 1
+            _remember(cfg, p["serial"], p.get("model"), host=adb_id.rpartition(":")[0],
+                      primary=True)
+            print(f"connected: {target} ({adb_id})")
+        if "--no-awake" in flags:
+            return 0
+        # connected means visible: bring up the mirror + keep-awake session too
+        return _start_awake_bg(mirror="--no-mirror" not in flags
+                               and bool(config.get("android.mirror")))
 
     if cmd == "use":
         if len(args) < 2 or args[1] not in phones:


### PR DESCRIPTION
## Why

`phone-harness android connect` stopped at a working adb link. The scrcpy mirror and keep-awake pokes lived behind a separate `android awake --bg` that an agent had to think to run — in practice it didn't, and the user had to ask for "the preview" after every connect. Connected should mean visible.

## What

- New `_start_awake_bg()` — the detached keep-awake + scrcpy spawn `awake --bg` already did, now shared. No-op (`already awake (pid …)`) if a session is running.
- `android connect [NAME|IP:PORT]` starts that session after a successful connect. `--no-awake` connects only; `--no-mirror` keeps awake without a window; `android.mirror` config still respected.
- `android pair` does the same after its connect.
- `awake --bg` routes through the helper (behavior unchanged).
- `SKILL.md` / `install.md`: "Connecting = seeing" + the flags.

## Tested (G45 over Wi‑Fi)

- fresh `connect` → `connected: g45 (…)` + `awake in background` + scrcpy window up
- second `connect` → `already awake`, no second window
- `connect --no-awake` → connected, no session, no scrcpy
- `connect IP:PORT` form → session starts
- `connect nope` → error, exit 1, no session
- `awake --bg` with one running → `already awake`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
