### PR TITLE
ocr: recognize the phone's language, not just Latin script

### DIFF
--- a/src/phone_harness/ocr.py
+++ b/src/phone_harness/ocr.py
@@ -3,9 +3,64 @@
 This is the mirror backend's element tree: OCR gives every visible string a
 bounding box, converted here into global screen points ready for tap().
 """
+import functools
+import os
+import sys
+
 import Quartz
 import Vision
-from Foundation import NSURL
+from Foundation import NSURL, NSLocale
+
+
+@functools.lru_cache(maxsize=1)
+def _supported():
+    """Language tags Vision can recognize at the Accurate level.
+
+    Accurate only: the Fast level supports six Latin languages and no CJK at
+    all, so anything that ever flips the level for speed silently loses
+    non-Latin recognition. Measured: Fast reports 6 languages, Accurate 30.
+    """
+    req = Vision.VNRecognizeTextRequest.alloc().init()
+    req.setRecognitionLevel_(Vision.VNRequestTextRecognitionLevelAccurate)
+    langs, _ = req.supportedRecognitionLanguagesAndReturnError_(None)
+    return [str(l) for l in langs or []]
+
+
+def _known(tag):
+    """Does Vision know this tag? Compared on the language prefix, because
+    Vision accepts a fuller tag than it advertises: `zh-Hant-TW` works even
+    though the supported list only reports `zh-Hant`."""
+    base = tag.split("-")[0].lower()
+    return any(s.split("-")[0].lower() == base for s in _supported())
+
+
+@functools.lru_cache(maxsize=1)
+def _languages():
+    """Recognition languages: the Mac's preferred languages, English last.
+
+    Vision defaults to Latin-script recognition, so a phone showing Chinese
+    (or any non-Latin script) OCRs to garbage. The Mac's own language list is
+    the best available guess at what the phone shows; English stays in the
+    list so a bilingual screen keeps working. PHONE_HARNESS_OCR_LANGS
+    overrides it outright ("zh-Hans,en-US") for phones whose language the
+    Mac does not share.
+
+    Unknown tags are warned about rather than passed through silently. Vision
+    accepts any string, returns Latin-only results, and reads the bogus value
+    straight back -- so a typo in the override would look like "OCR stopped
+    working" with nothing to go on.
+    """
+    override = os.environ.get("PHONE_HARNESS_OCR_LANGS")
+    if override:
+        tags = [l.strip() for l in override.split(",") if l.strip()]
+        bad = [t for t in tags if not _known(t)]
+        if bad:
+            print(f"phone-harness: PHONE_HARNESS_OCR_LANGS has tags Vision does "
+                  f"not recognize: {bad}. Supported: {', '.join(_supported())}",
+                  file=sys.stderr)
+        return tags
+    langs = [str(t) for t in NSLocale.preferredLanguages() or []]
+    return [*[l for l in langs if not l.startswith("en")], "en-US"]
 
 
 def image_size(path):
@@ -26,7 +81,16 @@ def recognize(path, window):
     handler = Vision.VNImageRequestHandler.alloc().initWithURL_options_(
         NSURL.fileURLWithPath_(path), {})
     request = Vision.VNRecognizeTextRequest.alloc().init()
+    # Accurate is not just a quality setting here: the Fast level knows six
+    # Latin languages and nothing else, so switching it for speed would drop
+    # every non-Latin script on the floor. See _supported().
     request.setRecognitionLevel_(Vision.VNRequestTextRecognitionLevelAccurate)
+    request.setRecognitionLanguages_(_languages())
+    # And let Vision spot a language the Mac's list missed (macOS 13+): the
+    # explicit list above acts as hints, detection covers the rest — a phone
+    # is not obliged to speak the same language as the Mac driving it.
+    if request.respondsToSelector_("setAutomaticallyDetectsLanguage:"):
+        request.setAutomaticallyDetectsLanguage_(True)
     ok, err = handler.performRequests_error_([request], None)
     if not ok:
         raise RuntimeError(f"Vision OCR failed: {err}")


### PR DESCRIPTION
## What does this PR do?

Vision's default recognition set is Latin-only, so a phone showing Chinese (or any non-Latin script) OCRs to garbage — every helper downstream of `ocr()` goes blind. `main` reads a `zh.wikipedia.org` capture as `'*#/Telegram EXI30:0ARh'`.

Two mechanisms, and review testing established which one matters:

1. **`automaticallyDetectsLanguage`** (macOS 13+, guarded) — **this carries the fix.** On an English-locale Mac it takes the capture from 8 garbled boxes to 33 correct ones on its own.
2. **`recognitionLanguages` from the Mac's locale**, overridable with `PHONE_HARNESS_OCR_LANGS` — on an English Mac this resolves to `["en-US"]` and is a no-op. Its value is the override: a phone whose language the Mac doesn't share.

## Related Issue

Second half of #13 (the window-discovery half landed in 95a74f6). Supersedes the `ocr.py` hunks of #37 and #38.

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📝 Documentation
- [ ] ♻️ Refactor
- [ ] ⚠️ Breaking change

## Changes Made

- `src/phone_harness/ocr.py` — set `recognitionLanguages` from locale or `PHONE_HARNESS_OCR_LANGS`; enable auto-detection; **validate override tags** against `supportedRecognitionLanguagesAndReturnError_` and warn on unknown ones (Vision otherwise accepts any string, returns Latin-only, and reads the bogus value back — a typo looked like "OCR stopped working"). Matched on language prefix, since Vision accepts `zh-Hant-TW` while advertising only `zh-Hant`.
- Docstring guard: the **Fast** recognition level supports 6 Latin languages and no CJK (Accurate: 30). Flipping it for speed silently kills non-Latin recognition.

## How did you verify it?

| | |
|---|---|
| macOS version | 26.5.2 |
| iPhone iOS | 26.2 |
| Transport | background (default) — OCR is transport-independent |
| Screen | Safari, `zh.wikipedia.org`, real iPhone Mirroring capture (not synthetic) |

One capture, run through each config. OCR is a pure function of the PNG, so this is a true ablation:

```
config                          boxes  CJK   sample
main (no language set)              8    0   '*#/Telegram EXI30:0ARh'
list only (locale -> ["en-US"])     8    0   identical — a no-op on an English Mac
auto only                          33   29   '三維基百科'
branch (list + auto)               33   29   '三維基百科'
override zh-Hans,en-US + auto      32   29   '三維基百科'
```

Override validation: `zh-Hant-TW, en-US` accepted (@LoTimmy's case); `zh-Hans,xx-YY,en-US` warns naming `xx-YY` and the supported list, and still returns.

Also verified by @LoTimmy on a zh-Hant-TW Mac (review) and by @fengziadmin on a zh-Hans Mac with a 16-line app UI: 0/14 Chinese lines → 14/14.

## Checklist

- [x] I pulled latest `main` first — rebased, 0 behind
- [x] `phone-harness --doctor` passes
- [x] This PR contains only changes for this one fix
- [ ] SKILL.md — N/A, no agent-facing behaviour change
- [x] Docstrings updated

## Anything you tried that did NOT work

Not taken from review: lowering `min_confidence` from 0.3 for CJK text, which scores lower and lands right on the threshold. It's a real observation but a default-threshold change deserves its own on-device measurement rather than a ride on this PR.

## Credit

Design follows #38 by @LoTimmy (locale list + override) and #37 by @ed3c (guarded auto-detection); both co-authors on the commit. Review testing by @fengziadmin isolated which mechanism carries the fix and surfaced the silent-typo and Fast-mode traps.
