### PR TITLE
Preserve macOS focus during background input

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -33,8 +33,8 @@ PY
 - `ensure_mirroring()` launches the window and gates on connection. The
   default build then works the phone **without focusing it**: capture is by
   window id and input is an event record delivered straight to the app, so a
-  task never steals the user's screen. `PHONE_HARNESS_BACKGROUND=0` forces the
-  classic path, which must focus before every action.
+  task never steals the user's screen. Focus-taking input is disabled; never
+  bypass the background transport or activate iPhone Mirroring.
 
 ## Screen Workflow
 
@@ -65,11 +65,9 @@ PY
   it. In the background build these scroll with momentum flicks — wheel
   events only route to a *focused* window, and a slow touch-drag barely moves
   an iOS list before bouncing back; only a fast flick carries it.
-- Raw Quartz is the escape hatch: `import Quartz` in your script for anything
-  the helpers don't cover — but raw CGEvents don't ride the helpers' delivery
-  path. They land only while the window is frontmost and are swallowed
-  silently otherwise, scroll-wheel events included: `activate()` first, then
-  verify the screen actually changed.
+- Raw Quartz events do not ride the helpers' background delivery path. If an
+  operation would require activating iPhone Mirroring, stop instead of posting
+  it; taking over the user's Mac is not an available fallback.
 
 ## Android
 
@@ -142,12 +140,9 @@ raises a clear message (call `connection_state()` yourself to check —
 ## Gotchas
 
 - **Unfocused input is swallowed silently — for events you post yourself.**
-  The helpers are immune in the background build (input goes straight to the
-  app), but raw CGEvents and the `PHONE_HARNESS_BACKGROUND=0` path need the
-  window frontmost: `activate()` before posting, and re-activate if a click
-  steals focus mid-task. The failure looks exactly like "scrolling is broken"
-  or "the list already ended" — when a gesture changes nothing on screen,
-  check focus before inventing another theory.
+  The helpers are immune because input goes straight to the app. Raw CGEvents
+  require the window frontmost, so do not use them as a fallback; when a
+  gesture changes nothing, stop and report the unsupported operation.
 - **The window is a video stream.** macOS accessibility sees nothing inside
   it; AppleScript `click at` fails silently. Only HID-level CGEvents work.
 - **The window moves.** Never cache coordinates across calls; `ocr()` and

--- a/SKILL.md
+++ b/SKILL.md
@@ -31,10 +31,11 @@ PY
 - Invoke as `phone-harness`. Use heredocs for multi-line commands.
 - Helpers are pre-imported. All coordinates are global screen points.
 - `ensure_mirroring()` launches the window and gates on connection. The
-  default build then works the phone **without focusing it**: capture is by
-  window id and input is an event record delivered straight to the app, so a
-  task never steals the user's screen. Focus-taking input is disabled; never
-  bypass the background transport or activate iPhone Mirroring.
+  default build reads and touches the phone **without focusing it**: capture is
+  by window id and pointer input is delivered straight to the app. macOS does
+  not forward keyboard input to inactive iPhone Mirroring sessions, so
+  `type_text`, `press`, and keyboard-backed navigation refuse unless the user
+  has already made Mirroring frontmost. Never activate it on the user's behalf.
 
 ## Screen Workflow
 
@@ -51,9 +52,9 @@ PY
   the window offset manually.
 - **Verify after every action**: `wait_stable()` then `ocr()`/`screenshot()`.
   There is no DOM to assert against; the capture is the ground truth.
-- Navigation: `home()`, `app_switcher()`, `open_app("Notes")` (Spotlight),
-  `swipe("up")`, `scroll()`, `type_text("...")`, `press("return")`,
-  `long_press(x, y)`.
+- Touch navigation: `swipe("up")`, `scroll()`, `long_press(x, y)`. Keyboard
+  helpers (`home()`, `app_switcher()`, `open_app()`, `type_text()`, `press()`)
+  require iPhone Mirroring to already be frontmost and otherwise fail visibly.
 - **Scrolling a list**: use `scroll_collect(extract, key=...)` to walk a list
   to its true end, de-duping as it goes — it returns `{items, stop, scrolls}`
   where `stop` is `'reached-end'` or `'max-scrolls'`. Use `scroll_until(done)`
@@ -139,10 +140,10 @@ raises a clear message (call `connection_state()` yourself to check —
 
 ## Gotchas
 
-- **Unfocused input is swallowed silently — for events you post yourself.**
-  The helpers are immune because input goes straight to the app. Raw CGEvents
-  require the window frontmost, so do not use them as a fallback; when a
-  gesture changes nothing, stop and report the unsupported operation.
+- **Unfocused keyboard input is swallowed by iPhone Mirroring.** Pointer
+  helpers work in the background, but keyboard helpers refuse unless the user
+  already focused Mirroring. Do not activate it or use raw CGEvents as a
+  fallback; ask the user to focus it when keyboard input is required.
 - **The window is a video stream.** macOS accessibility sees nothing inside
   it; AppleScript `click at` fails silently. Only HID-level CGEvents work.
 - **The window moves.** Never cache coordinates across calls; `ocr()` and

--- a/src/phone_harness/background.py
+++ b/src/phone_harness/background.py
@@ -27,8 +27,9 @@ Select with PHONE_HARNESS_BACKGROUND=1. Coordinates use the same global
 screen-point convention as the mirror backend and ocr(), so every helper on
 top (tap_text, swipe, scroll_collect) works unchanged — just without focus.
 
-Keyboard makes the mirroring window key inside its own process, then posts the
-key event directly to that process without requesting front-process activation.
+macOS drops iPhone Mirroring keyboard events while the app is inactive. This
+backend delivers them only when the user has already made Mirroring frontmost;
+it never activates the app on the user's behalf.
 """
 import ctypes, ctypes.util, os, struct, subprocess, tempfile, time
 from contextlib import contextmanager
@@ -243,13 +244,18 @@ def scroll_wheel(dy, x, y, steps=6):
     _emit(_LMOUSE_UP, x, y1, pid, win)
 
 
-# --- keyboard (background), via make-key + CGEventPostToPid ---
+# --- keyboard, only when Mirroring is already frontmost ---
 #
-# Keyboard is delivered differently from mouse: the keystroke goes to the key
-# window's text responder. Making the window key (yabai's focus record: a
-# down/up pair with a blanked location) and then posting the key event to the
-# process by pid lands the text with no activation — verified by typing into
-# Spotlight while another app stayed frontmost.
+# Unlike pointer records, keyboard events do not cross iPhone Mirroring's
+# remote-HID active-app gate. Refuse instead of silently dropping input or
+# taking focus from the user's current Mac app.
+
+def _require_keyboard_focus():
+    if not is_frontmost():
+        raise RuntimeError(
+            "iPhone Mirroring must already be frontmost for keyboard input; "
+            "phone-harness will not take focus from the current Mac app")
+
 
 def _make_key(pid, wid):
     buf = (ctypes.c_uint8 * 0xf8)()
@@ -303,7 +309,8 @@ def _holding(pid, wid, mods):
 
 
 def press(combo):
-    """press('return'), press('cmd+1'), press('cmd+3') — no focus change."""
+    """Press a key without changing which Mac app is frontmost."""
+    _require_keyboard_focus()
     pid, win = _ctx()
     parts = combo.lower().split("+")
     key, mods = parts[-1], parts[:-1]
@@ -333,11 +340,12 @@ def _type_keystrokes(text, delay=0.03):
 
 
 def type_text(text, delay=0.03, keystrokes=False):
-    """Type into the focused iOS field, no focus change.
+    """Type when Mirroring is already frontmost; never take Mac focus.
 
     Pastes by default so the text arrives exactly as written, past autocorrect
     and keyboard layout both. keystrokes=True sends real key events instead.
     """
+    _require_keyboard_focus()           # before paste_with changes the clipboard
     if keystrokes or not text:
         return _type_keystrokes(text, delay)
     mirror.paste_with(press, text)

--- a/src/phone_harness/background.py
+++ b/src/phone_harness/background.py
@@ -11,13 +11,10 @@ unfocused and another app frontmost:
   EYES  - CGWindowListCreateImage captures a specific window by id even when it
           is not the active app (and even when occluded).
 
-  HANDS - the input path macOS actually gates on is the app being *active*, not
-          merely its window being key. A normal CGEvent can't cross that. But
-          the window server accepts a synthesized event record delivered
-          straight to a process via SkyLight's SLPSPostEventRecordTo (the same
-          mechanism yabai uses to focus windows without raising them). Written
-          with a real location, it lands a positioned tap/drag in iPhone
-          Mirroring while your frontmost app never changes.
+  HANDS - a normal CGEvent cannot target an inactive app. The window server can
+          instead deliver a synthesized event record straight to a process via
+          SkyLight's SLPSPostEventRecordTo. The record names both the process and
+          window, so delivery no longer requests front-process activation.
 
 The event-record layout is yabai's (window_manager_make_key_window): a 0xf8
 buffer, length at 0x04, CGSEventType at 0x08 (1=down, 2=up, 6=dragged),
@@ -30,16 +27,14 @@ Select with PHONE_HARNESS_BACKGROUND=1. Coordinates use the same global
 screen-point convention as the mirror backend and ocr(), so every helper on
 top (tap_text, swipe, scroll_collect) works unchanged — just without focus.
 
-Keyboard (type_text/press) still briefly activates the window: the keyboard
-event-record layout isn't implemented yet, so those fall back to the mirror
-path. Mouse actions are fully background.
+Keyboard makes the mirroring window key inside its own process, then posts the
+key event directly to that process without requesting front-process activation.
 """
 import ctypes, ctypes.util, os, struct, subprocess, tempfile, time
 from contextlib import contextmanager
 from pathlib import Path
 
 import Quartz
-from AppKit import NSRunningApplication
 
 from . import mirror
 
@@ -59,11 +54,9 @@ class _PSN(ctypes.Structure):
 
 _appserv.GetProcessForPID.argtypes = [ctypes.c_int, ctypes.POINTER(_PSN)]
 _appserv.GetProcessForPID.restype = ctypes.c_int
-_sky._SLPSSetFrontProcessWithOptions.argtypes = [
-    ctypes.POINTER(_PSN), ctypes.c_uint32, ctypes.c_uint32]
 _sky.SLPSPostEventRecordTo.argtypes = [ctypes.POINTER(_PSN), ctypes.c_void_p]
+_sky.SLPSPostEventRecordTo.restype = ctypes.c_int
 
-_KCPS_USER_GENERATED = 0x200
 # CGSEventType values (share the CGEventType numbering)
 _LMOUSE_DOWN, _LMOUSE_UP, _LMOUSE_DRAGGED = 1, 2, 6
 
@@ -162,6 +155,23 @@ def _screencapture(win, path):
 
 # --- input (hands), no focus ---
 
+def _process_serial_number(pid):
+    psn = _PSN()
+    status = _appserv.GetProcessForPID(pid, ctypes.byref(psn))
+    if status != 0:
+        raise RuntimeError(
+            f"could not resolve iPhone Mirroring process {pid} "
+            f"to a process serial number (status {status})")
+    return psn
+
+
+def _post_record(psn, buf):
+    status = _sky.SLPSPostEventRecordTo(ctypes.byref(psn), ctypes.byref(buf))
+    if status != 0:
+        raise RuntimeError(
+            f"could not deliver an event to iPhone Mirroring (status {status})")
+
+
 def _post(pid, wid, etype, gx, gy, lx, ly):
     """Deliver one synthesized mouse event record to the process by pid."""
     buf = (ctypes.c_uint8 * 0xf8)()
@@ -171,10 +181,7 @@ def _post(pid, wid, etype, gx, gy, lx, ly):
     struct.pack_into("<dd", buf, 0x10, gx, gy)      # location (global points)
     struct.pack_into("<dd", buf, 0x20, lx, ly)      # windowLocation (local)
     buf[0x08] = etype
-    psn = _PSN()
-    _appserv.GetProcessForPID(pid, ctypes.byref(psn))
-    _sky._SLPSSetFrontProcessWithOptions(ctypes.byref(psn), wid, _KCPS_USER_GENERATED)
-    _sky.SLPSPostEventRecordTo(ctypes.byref(psn), ctypes.byref(buf))
+    _post_record(_process_serial_number(pid), buf)
 
 
 def _ctx():
@@ -251,13 +258,11 @@ def _make_key(pid, wid):
     struct.pack_into("<I", buf, 0x3c, wid)
     for i in range(0x10):
         buf[0x20 + i] = 0xff            # blanked location => "focus", not a click
-    psn = _PSN()
-    _appserv.GetProcessForPID(pid, ctypes.byref(psn))
-    _sky._SLPSSetFrontProcessWithOptions(ctypes.byref(psn), wid, _KCPS_USER_GENERATED)
+    psn = _process_serial_number(pid)
     buf[0x08] = _LMOUSE_DOWN
-    _sky.SLPSPostEventRecordTo(ctypes.byref(psn), ctypes.byref(buf))
+    _post_record(psn, buf)
     buf[0x08] = _LMOUSE_UP
-    _sky.SLPSPostEventRecordTo(ctypes.byref(psn), ctypes.byref(buf))
+    _post_record(psn, buf)
 
 
 def _key_edge(pid, wid, code, down, flags=0):

--- a/src/phone_harness/ios.py
+++ b/src/phone_harness/ios.py
@@ -38,17 +38,20 @@ _BLOCKED_MARKERS = ("iphone in use", "lock your iphone", "mirroring ended",
 
 def _load_transport():
     """background drives iPhone Mirroring without ever taking the window to the
-    front (SkyLight event records) and is the default: not covering the user's
-    screen is what you want unless something is broken. Its private SkyLight
-    symbols are not guaranteed across macOS builds, so fall back rather than
-    leaving the harness unusable."""
+    front (SkyLight event records) and is the default. Its private SkyLight
+    symbols are not guaranteed across macOS builds, so an unavailable background
+    backend fails visibly. Falling back would silently select the classic backend,
+    whose contract requires taking focus."""
     want_bg = os.environ.get("PHONE_HARNESS_BACKGROUND", "1").lower() not in (
         "0", "false", "no")
     if want_bg:
         try:
             return importlib.import_module(".background", __package__), True
-        except Exception:
-            pass
+        except Exception as exc:
+            raise RuntimeError(
+                "focus-free iPhone input is unavailable on this Mac. "
+                "Set PHONE_HARNESS_BACKGROUND=0 only if bringing iPhone "
+                "Mirroring to the front is acceptable.") from exc
     return importlib.import_module(".mirror", __package__), False
 
 

--- a/src/phone_harness/ios.py
+++ b/src/phone_harness/ios.py
@@ -38,21 +38,18 @@ _BLOCKED_MARKERS = ("iphone in use", "lock your iphone", "mirroring ended",
 
 def _load_transport():
     """background drives iPhone Mirroring without ever taking the window to the
-    front (SkyLight event records) and is the default. Its private SkyLight
-    symbols are not guaranteed across macOS builds, so an unavailable background
-    backend fails visibly. Falling back would silently select the classic backend,
-    whose contract requires taking focus."""
-    want_bg = os.environ.get("PHONE_HARNESS_BACKGROUND", "1").lower() not in (
-        "0", "false", "no")
-    if want_bg:
-        try:
-            return importlib.import_module(".background", __package__), True
-        except Exception as exc:
-            raise RuntimeError(
-                "focus-free iPhone input is unavailable on this Mac. "
-                "Set PHONE_HARNESS_BACKGROUND=0 only if bringing iPhone "
-                "Mirroring to the front is acceptable.") from exc
-    return importlib.import_module(".mirror", __package__), False
+    front (SkyLight event records). The classic backend is intentionally not
+    selectable: it moves the user's pointer and takes macOS focus."""
+    if os.environ.get("PHONE_HARNESS_BACKGROUND", "1").lower() in (
+            "0", "false", "no"):
+        raise RuntimeError(
+            "focus-taking iPhone input is disabled; remove "
+            "PHONE_HARNESS_BACKGROUND=0")
+    try:
+        return importlib.import_module(".background", __package__), True
+    except Exception as exc:
+        raise RuntimeError(
+            "focus-free iPhone input is unavailable on this Mac.") from exc
 
 
 class IPhone(Backend):

--- a/tests/test_background_delivery.py
+++ b/tests/test_background_delivery.py
@@ -1,0 +1,61 @@
+import unittest
+from unittest import mock
+
+from phone_harness import background
+
+
+class RecordingSkyLight:
+    def __init__(self, status=0):
+        self.status = status
+        self.posts = 0
+
+    def SLPSPostEventRecordTo(self, psn, record):
+        self.posts += 1
+        return self.status
+
+
+class FailingApplicationServices:
+    def GetProcessForPID(self, pid, psn):
+        return -600
+
+
+class BackgroundDeliveryTests(unittest.TestCase):
+    def test_mouse_record_is_posted_without_fronting_the_process(self):
+        sky = RecordingSkyLight()
+
+        with mock.patch.object(background, "_sky", sky), \
+                mock.patch.object(
+                    background, "_process_serial_number",
+                    return_value=background._PSN()):
+            background._post(123, 456, 1, 10, 20, 5, 6)
+
+        self.assertEqual(1, sky.posts)
+
+    def test_make_key_posts_both_edges_without_fronting_the_process(self):
+        sky = RecordingSkyLight()
+
+        with mock.patch.object(background, "_sky", sky), \
+                mock.patch.object(
+                    background, "_process_serial_number",
+                    return_value=background._PSN()):
+            background._make_key(123, 456)
+
+        self.assertEqual(2, sky.posts)
+
+    def test_event_delivery_error_is_visible(self):
+        sky = RecordingSkyLight(status=1000)
+        record = (background.ctypes.c_uint8 * 0xf8)()
+
+        with mock.patch.object(background, "_sky", sky):
+            with self.assertRaisesRegex(RuntimeError, "status 1000"):
+                background._post_record(background._PSN(), record)
+
+    def test_process_lookup_error_is_visible(self):
+        with mock.patch.object(
+                background, "_appserv", FailingApplicationServices()):
+            with self.assertRaisesRegex(RuntimeError, "status -600"):
+                background._process_serial_number(123)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_background_delivery.py
+++ b/tests/test_background_delivery.py
@@ -56,6 +56,13 @@ class BackgroundDeliveryTests(unittest.TestCase):
             with self.assertRaisesRegex(RuntimeError, "status -600"):
                 background._process_serial_number(123)
 
+    def test_background_keyboard_refuses_before_mutating_input(self):
+        with mock.patch.object(background, "is_frontmost", return_value=False), \
+                mock.patch.object(background.mirror, "paste_with") as paste:
+            with self.assertRaisesRegex(RuntimeError, "must already be frontmost"):
+                background.type_text("hello")
+        paste.assert_not_called()
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_ios_transport.py
+++ b/tests/test_ios_transport.py
@@ -1,0 +1,29 @@
+import importlib
+import os
+import unittest
+from unittest import mock
+
+from phone_harness import ios
+
+
+class IOSTransportSelectionTests(unittest.TestCase):
+    def test_background_import_failure_does_not_select_focused_backend(self):
+        failure = OSError("missing private symbol")
+
+        with mock.patch.dict(os.environ, {"PHONE_HARNESS_BACKGROUND": "1"}), \
+                mock.patch.object(importlib, "import_module", side_effect=failure):
+            with self.assertRaisesRegex(RuntimeError, "focus-free iPhone input"):
+                ios._load_transport()
+
+    def test_classic_backend_remains_an_explicit_opt_in(self):
+        classic = object()
+
+        with mock.patch.dict(os.environ, {"PHONE_HARNESS_BACKGROUND": "0"}), \
+                mock.patch.object(importlib, "import_module", return_value=classic) as load:
+            self.assertEqual((classic, False), ios._load_transport())
+
+        load.assert_called_once_with(".mirror", ios.__package__)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_ios_transport.py
+++ b/tests/test_ios_transport.py
@@ -15,14 +15,13 @@ class IOSTransportSelectionTests(unittest.TestCase):
             with self.assertRaisesRegex(RuntimeError, "focus-free iPhone input"):
                 ios._load_transport()
 
-    def test_classic_backend_remains_an_explicit_opt_in(self):
-        classic = object()
-
+    def test_classic_backend_is_rejected(self):
         with mock.patch.dict(os.environ, {"PHONE_HARNESS_BACKGROUND": "0"}), \
-                mock.patch.object(importlib, "import_module", return_value=classic) as load:
-            self.assertEqual((classic, False), ios._load_transport())
+                mock.patch.object(importlib, "import_module") as load:
+            with self.assertRaisesRegex(RuntimeError, "focus-taking.*disabled"):
+                ios._load_transport()
 
-        load.assert_called_once_with(".mirror", ios.__package__)
+        load.assert_not_called()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- stop calling `_SLPSSetFrontProcessWithOptions` during background pointer delivery
- reject the focus-taking classic backend instead of falling back to it
- fail visibly on keyboard-backed actions while iPhone Mirroring is inactive, before posting an event or changing the clipboard
- continue to allow keyboard input when the user has already made iPhone Mirroring frontmost

## Root cause

The background backend copied yabai’s focus sequence. `_SLPSSetFrontProcessWithOptions` preserves window order but still transfers keyboard focus. Removing it fixed the hijack, but revealed a second macOS contract: iPhone Mirroring is a remote-HID proxy and drops keyboard events unless its app is active.

Targeted `CGEventPostToPid`, SkyLight `SLEventPostToPid`, authenticated SkyLight keyboard events, Unicode events, and no-raise focus records were tested. The non-activating routes were dropped. The routes that delivered input made `AXFrontmost` transiently true. The safe behavior is therefore to refuse inactive keyboard delivery rather than steal focus or report false success.

## Checks

- `PYTHONPATH=src .venv/bin/python -m unittest discover -s tests -v` — 7 passed
- `git diff --check` — passed
- editable installed command resolves to this checkout

## Live verification

On iPhone Mirroring with Buoy open and a focused composer:

- background taps changed the phone while Mirroring stayed inactive
- direct inactive keyboard events did not change the phone
- every delivery recipe that changed phone text produced a sampled `AXFrontmost=true` interval
- the final installed command refused `type_text` while inactive; front app, Mirroring focus/depth, and clipboard hash stayed unchanged

This PR does not claim impossible background keyboard delivery. Keyboard-backed helpers now name the required user action: make iPhone Mirroring frontmost first.