### PR TITLE
Add sponsor links

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: ShawnPana

--- a/README.md
+++ b/README.md
@@ -137,3 +137,8 @@ PY
   key chords are not a thing over adb; a PIN-locked phone needs the user.
 - Both: no multi-touch (no pinch), no camera/Face ID flows, DRM video renders
   black. Connecting the phone is always the user's job.
+
+## Sponsor
+
+phone-harness is free and maintained in my own time.
+[Sponsoring](https://github.com/sponsors/ShawnPana) keeps it that way.


### PR DESCRIPTION
Now that GitHub Sponsors is live at https://github.com/sponsors/ShawnPana, this surfaces it on the repo.

- `.github/FUNDING.yml` — adds the **Sponsor** button to the repo header, next to Watch/Fork/Star.
- `README.md` — short sponsor section after `## Limits`, written to match the existing tone.

Nothing else changes. Both are reversible by deleting the file / section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)