### PR TITLE
chore: add a pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,81 @@
+## What does this PR do?
+
+<!-- What breaks today, and what does this change about it? One paragraph is plenty. -->
+
+
+
+## Related Issue
+
+<!-- Link it. If there is no issue, describe the symptom you hit here instead. -->
+
+Fixes #
+
+## Type of Change
+
+- [ ] 🐛 Bug fix
+- [ ] ✨ New feature
+- [ ] 📝 Documentation
+- [ ] ♻️ Refactor (no behaviour change)
+- [ ] ⚠️ Breaking change (describe it under Changes Made)
+
+## Changes Made
+
+<!-- The specific changes, with file paths. -->
+
+-
+
+## How did you verify it?
+
+**This repo has no test suite. Verification happens on a phone, so this section
+is the review.** Tell us what you *observed*, not what you expect to happen.
+
+| | |
+|---|---|
+| macOS version | |
+| iPhone iOS / Android version | |
+| Transport | background (default) / mirror (`PHONE_HARNESS_BACKGROUND=0`) / adb |
+| App or screen you tested on | |
+
+**Before the change** — what the phone did, and what the harness reported:
+
+```
+
+```
+
+**After the change** — same:
+
+```
+
+```
+
+<!--
+Two things worth knowing, because they have burned us repeatedly:
+
+  * "nothing happened" is ambiguous. A list already at its end looks exactly
+    like a broken gesture. Say how you knew there was somewhere left to go.
+
+  * a helper returning success is not evidence. `moved=True` has been returned
+    for a screen that never changed. Say what you saw on the phone.
+-->
+
+## Checklist
+
+- [ ] I pulled latest `main` first and confirmed the bug still happens
+      <!-- Several PRs have re-fixed things that were already fixed. -->
+- [ ] `phone-harness --doctor` passes on my machine
+- [ ] This PR contains only changes for this one fix
+- [ ] I updated `SKILL.md` if I changed what an agent should do — or N/A
+- [ ] I updated docstrings if I changed what a helper returns — or N/A
+
+## Anything you tried that did NOT work
+
+<!-- Optional, and genuinely useful. The dead ends are usually the expensive
+     part to rediscover, and they tell a reviewer which explanations are
+     already ruled out. -->
+
+-
+
+## Screenshots / Logs
+
+<!-- Screen recordings are ideal for gesture changes: before/after stills miss
+     a gesture that fires and then gets undone. -->


### PR DESCRIPTION
## What does this PR do?

Adds `.github/PULL_REQUEST_TEMPLATE.md`, so every new PR arrives with the
information a reviewer needs instead of having to ask for it.

Structure is borrowed from [NousResearch/hermes-agent](https://github.com/NousResearch/hermes-agent),
with the checklist replaced by things that actually matter here.

This repo has no test suite — a change is reviewed by whether someone can tell
what the phone did. So that is the biggest section, and it asks for what the
contributor **observed**, separately from what the harness **reported**. Those
two have disagreed: `moved=True` has come back for a screen that never changed.

Two prompts exist because they have cost real debugging time:

- *"nothing happened" is ambiguous.* A list already at its end looks exactly
  like a broken gesture, so the template asks how you knew there was somewhere
  left to go.
- *a helper returning success is not evidence.* Say what you saw on the phone.

The checklist also asks contributors to pull latest `main` and confirm the bug
still reproduces — six open PRs were recently closed as already-fixed, which
wastes the contributor's time as much as ours.

## Related Issue

None — housekeeping.

## Type of Change

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [x] 📝 Documentation
- [ ] ♻️ Refactor (no behaviour change)
- [ ] ⚠️ Breaking change

## Changes Made

- `.github/PULL_REQUEST_TEMPLATE.md` *(new)* — sections: What / Related Issue /
  Type of Change / Changes Made / How did you verify it / Checklist / Anything
  that did NOT work / Screenshots.

## How did you verify it?

Not a code change, so nothing to run on a phone. GitHub picks the file up from
the default branch automatically; it applies to PRs opened after this merges,
and not to the ones already open.

Rendered preview: <https://github.com/ShawnPana/phone-harness/blob/chore/pr-template/.github/PULL_REQUEST_TEMPLATE.md>

## Checklist

- [x] I pulled latest `main` first
- [ ] `phone-harness --doctor` passes — N/A, no code change
- [x] This PR contains only changes for this one thing
- [ ] SKILL.md — N/A
- [ ] docstrings — N/A

## Anything you tried that did NOT work

Started from the full hermes-agent template and cut what does not apply here:
`pytest`, Conventional Commits, cross-platform checks, config keys, and the
skills section. Keeping them would have meant a template mostly full of "N/A",
which trains people to skip the whole thing.

## Screenshots / Logs

N/A.