### PR TITLE
fix(ocr): stop filtering boxes by confidence, and stop cropping the screen

### DIFF
--- a/src/phone_harness/helpers.py
+++ b/src/phone_harness/helpers.py
@@ -147,7 +147,13 @@ def ocr(min_confidence=0.3):
     """All visible text with tap-ready centers: [{text, confidence, source,
     x, y, w, h}]. Prefer this over eyeballing screenshots for anything with a
     text label. `source` is "pixels" when a recogniser inferred the string and
-    "tree" when the OS reported it exactly."""
+    "tree" when the OS reported it exactly.
+
+    Nothing is filtered. `min_confidence` is accepted and ignored: every box
+    carries its own `confidence`, and what counts as trustworthy depends on
+    the screen and the script -- Chinese text scores lower than English, and a
+    cutoff tuned on one silently drops the other.
+    """
     return send("screen.text", min_confidence=min_confidence)
 
 
@@ -364,15 +370,16 @@ def scroll(direction="down", amount=0.3, at=None):
 # as "done" — only the content going still (after a settle window that lets
 # lazy-loaded content arrive) means the end.
 
-def _content_texts(min_conf=0.4, top_frac=0.06, bottom_frac=0.92):
-    """Visible text within the scrollable band, excluding the volatile status
-    bar (clock/battery) at top and the nav/home strip at bottom — a clock that
-    ticks over would read as movement and stop end-detection ever firing."""
-    win = _win()
-    top = win["y"] + win["h"] * top_frac
-    bot = win["y"] + win["h"] * bottom_frac
-    return [o for o in ocr()
-            if top < o["y"] < bot and o["confidence"] >= min_conf]
+def _content_texts():
+    """Every visible text box. Nothing cropped, nothing filtered.
+
+    This used to crop the status bar and home strip and drop low-confidence
+    boxes, to keep a ticking clock from tripping the old movement test. That
+    test is gone. scroll_collect de-dupes, so a clock ticking over costs at
+    most one spurious item a minute -- while the crop was hiding nav bars and
+    tab bars from every walk, and the cutoff was dropping Chinese rows.
+    """
+    return ocr()
 
 
 def _text_set(boxes):

--- a/src/phone_harness/ios.py
+++ b/src/phone_harness/ios.py
@@ -73,10 +73,17 @@ class IPhone(Backend):
         return self.mirror.capture(path)
 
     def _screen_text(self, min_confidence=0.3):
+        """Every string Vision found, with its confidence attached.
+
+        `min_confidence` is accepted and ignored. It used to drop boxes below
+        a cutoff before the caller saw them -- and the cutoff was tuned on
+        English. Chinese text scores lower and landed on exactly 0.3, one
+        rounding step from vanishing, so on a Chinese phone rows silently went
+        missing. The score is in every box; what to do with it is the
+        caller's call, not this function's.
+        """
         path, win = self.mirror.capture()
-        return [dict(o, source="pixels")
-                for o in _vision.recognize(path, win)
-                if o["confidence"] >= min_confidence]
+        return [dict(o, source="pixels") for o in _vision.recognize(path, win)]
 
     # Pixels are the only source iOS has ever had.
     _screen_text_pixels = _screen_text


### PR DESCRIPTION
## What does this PR do?

Two hidden cutoffs decided what text the agent got to see. `ocr()` dropped every box Vision scored under 0.3; `_content_texts()` — what `scroll_collect` and `scroll_until` walk — dropped under 0.4 *and* cropped the top 6% / bottom 8% of the screen.

Both were tuned on English. Chinese text scores lower, and on a Chinese phone a real row came back at exactly 0.3 — one rounding step from being silently filtered, so `scroll_collect` would skip rows and report `reached-end` early. Found by @fengziadmin reviewing #47.

Now `ocr()` returns every box with its `confidence` attached and filters nothing. What counts as trustworthy depends on the screen and the script; the score is there for whoever needs it. Same principle as #53: the harness reports, the agent decides.

## Related Issue

Follows from review on #47. Companion to it: #47 makes Vision *recognize* non-Latin text, this stops the harness *discarding* what it recognized.

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📝 Documentation
- [ ] ♻️ Refactor
- [ ] ⚠️ Breaking change — `min_confidence` is kept and ignored, so no signature breaks

## Changes Made

- `src/phone_harness/ios.py` — `_screen_text` no longer drops boxes under `min_confidence`
- `src/phone_harness/helpers.py` — `ocr()` documents that nothing is filtered; `_content_texts()` loses its confidence cutoff and its screen crop, and is now just `ocr()`

The crop existed to keep the status-bar clock from tripping the old OCR-overlap movement test, which #53 removed. What it was still doing was hiding nav bars and tab bars from every list walk.

## How did you verify it?

| | |
|---|---|
| macOS version | 26.5.2 |
| iPhone iOS | 26.2 |
| Transport | background (default) |
| Screen | Settings > General; Safari `zh.wikipedia.org` |

**Before** — a `zh.wikipedia.org` capture on this Mac produced three boxes scored exactly **0.3**, surviving only because the comparison was `>=`. That is the band the reviewer's Chinese rows fall in.

**After** — `scroll_collect` over Settings > General from a checked top, without the crop:

```
items=32  stop=reached-end  scrolls=4
first items: ['8:541', '•l z', 'General']            <- clock/status, now visible, de-duped to one item
last items : ['Legal & Regulatory', 'Transfer or Reset iPhone', 'Shut Down']   <- the true end
```

Still walks to the real bottom and stops for the right reason.

**Performance:** none. Vision already did the recognition; the filter ran on the results afterward.

**Not demonstrated:** a box the old cutoff would actually have dropped. English screens on this phone score ≥ 0.3 throughout, so the filter is invisible on English and only bites on non-Latin text. The evidence it bites is the reviewer's Chinese-phone measurement, not a local one — I'd rather say that than fake a demonstration.

## Checklist

- [x] I pulled latest `main` first
- [x] `phone-harness --doctor` passes
- [x] This PR contains only changes for this one fix
- [ ] SKILL.md — N/A; already says helpers return observations, not verdicts
- [x] Docstrings updated

## Anything you tried that did NOT work

Tried to produce a sub-0.3 box locally on the Home Screen and on Settings: 30 boxes, none under 0.3. English just scores high. That's the finding, not a failure to look.