### PR TITLE
fix(android): accept both scroll deltas

### DIFF
--- a/src/phone_harness/android.py
+++ b/src/phone_harness/android.py
@@ -302,12 +302,13 @@ class Android(Backend):
         self._sh(f"input swipe {int(x1)} {int(y1)} {int(x2)} {int(y2)} "
                  f"{int(duration * 1000)}")
 
-    def _input_scroll(self, x, y, dy, steps=6):
+    def _input_scroll(self, x, y, dy, steps=6, dx=0):
         """A finger drag standing in for a wheel: +dy moves content up the
         way wheel-up does (revealing what is above), so the finger travels
-        +dy pixels downward. Slow enough not to fling."""
+        +dy pixels downward; +dx likewise moves the finger right. Slow
+        enough not to fling."""
         self._gate()
-        self._sh(f"input swipe {int(x)} {int(y)} {int(x)} {int(y + dy)} "
+        self._sh(f"input swipe {int(x)} {int(y)} {int(x + dx)} {int(y + dy)} "
                  f"{max(150, int(steps) * 50)}")
 
     def _input_keys(self, combo):

--- a/src/phone_harness/android.py
+++ b/src/phone_harness/android.py
@@ -303,10 +303,9 @@ class Android(Backend):
                  f"{int(duration * 1000)}")
 
     def _input_scroll(self, x, y, dy, steps=6, dx=0):
-        """A finger drag standing in for a wheel: +dy moves content up the
-        way wheel-up does (revealing what is above), so the finger travels
-        +dy pixels downward; +dx likewise moves the finger right. Slow
-        enough not to fling."""
+        """A finger drag standing in for a wheel: +dy moves the finger and
+        content downward, revealing what is above; +dx likewise moves them
+        right, revealing what is to the left. Slow enough not to fling."""
         self._gate()
         self._sh(f"input swipe {int(x)} {int(y)} {int(x + dx)} {int(y + dy)} "
                  f"{max(150, int(steps) * 50)}")

--- a/tests/test_android_scroll.py
+++ b/tests/test_android_scroll.py
@@ -1,0 +1,37 @@
+import os
+import unittest
+from unittest.mock import patch
+
+with patch.dict(os.environ, {"PHONE_HARNESS_PLATFORM": "android"}):
+    from phone_harness import helpers
+from phone_harness.android import Android
+
+
+class AndroidScrollTests(unittest.TestCase):
+    def test_public_scroll_sends_a_drag_in_each_direction(self):
+        phone = Android(serial="test-device")
+        bounds = {"x": 0, "y": 0, "w": 1000, "h": 2000, "id": "test-device"}
+        expected = {
+            "down": "input swipe 500 1000 500 500 300",
+            "up": "input swipe 500 1000 500 1500 300",
+            "right": "input swipe 500 1000 250 1000 300",
+            "left": "input swipe 500 1000 750 1000 300",
+        }
+        with patch.object(helpers, "phone", phone), \
+             patch.object(phone, "_screen_require", return_value=bounds), \
+             patch.object(phone, "_gate"), patch.object(phone, "_sh") as shell:
+            for direction, command in expected.items():
+                with self.subTest(direction=direction):
+                    shell.reset_mock()
+                    helpers.scroll(direction, amount=0.25)
+                    shell.assert_called_once_with(command)
+
+    def test_raw_vertical_scroll_keeps_existing_positional_arguments(self):
+        phone = Android(serial="test-device")
+        with patch.object(phone, "_gate"), patch.object(phone, "_sh") as shell:
+            phone._input_scroll(100, 200, 30, 2)
+            shell.assert_called_once_with("input swipe 100 200 100 230 150")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_android_scroll.py
+++ b/tests/test_android_scroll.py
@@ -1,5 +1,6 @@
 import os
 import unittest
+from contextlib import ExitStack
 from unittest.mock import patch
 
 with patch.dict(os.environ, {"PHONE_HARNESS_PLATFORM": "android"}):
@@ -8,29 +9,90 @@ from phone_harness.android import Android
 
 
 class AndroidScrollTests(unittest.TestCase):
-    def test_public_scroll_sends_a_drag_in_each_direction(self):
-        phone = Android(serial="test-device")
+    def setUp(self):
+        stack = ExitStack()
+        self.addCleanup(stack.close)
+        self.phone = Android()
         bounds = {"x": 0, "y": 0, "w": 1000, "h": 2000, "id": "test-device"}
+        stack.enter_context(patch.object(helpers, "phone", self.phone))
+        stack.enter_context(patch.object(self.phone, "_screen_require", return_value=bounds))
+        stack.enter_context(patch.object(self.phone, "_gate"))
+        self.shell = stack.enter_context(patch.object(self.phone, "_sh"))
+        self.text = stack.enter_context(patch.object(self.phone, "_screen_text"))
+        stack.enter_context(patch.object(helpers.time, "sleep"))
+
+    def test_public_scroll_sends_a_drag_in_each_direction(self):
         expected = {
             "down": "input swipe 500 1000 500 500 300",
             "up": "input swipe 500 1000 500 1500 300",
             "right": "input swipe 500 1000 250 1000 300",
             "left": "input swipe 500 1000 750 1000 300",
         }
-        with patch.object(helpers, "phone", phone), \
-             patch.object(phone, "_screen_require", return_value=bounds), \
-             patch.object(phone, "_gate"), patch.object(phone, "_sh") as shell:
-            for direction, command in expected.items():
-                with self.subTest(direction=direction):
-                    shell.reset_mock()
-                    helpers.scroll(direction, amount=0.25)
-                    shell.assert_called_once_with(command)
+        for direction, command in expected.items():
+            with self.subTest(direction=direction):
+                self.shell.reset_mock()
+                helpers.scroll(direction, amount=0.25)
+                self.shell.assert_called_once_with(command)
+
+    def test_scroll_screen_sends_each_direction_and_preserves_text_sets(self):
+        before = [{"text": "First", "y": 500, "confidence": 1.0}]
+        after = [{"text": "Second", "y": 500, "confidence": 1.0}]
+        expected = {
+            "down": "input swipe 500 1000 500 500 500",
+            "up": "input swipe 500 1000 500 1500 500",
+            "right": "input swipe 500 1000 250 1000 500",
+            "left": "input swipe 500 1000 750 1000 500",
+        }
+        for direction, command in expected.items():
+            for settled in (after, before):
+                with self.subTest(direction=direction, settled=settled):
+                    self.shell.reset_mock()
+                    self.text.side_effect = [before, settled]
+                    result = helpers.scroll_screen(direction, amount=0.25, settle=0)
+                    self.shell.assert_called_once_with(command)
+                    self.assertEqual(result, {
+                        "before": frozenset({"First"}),
+                        "after": frozenset(box["text"] for box in settled),
+                        "boxes": settled,
+                    })
+
+    def test_scroll_until_finds_content_after_android_scroll(self):
+        before = [{"text": "First", "y": 500, "confidence": 1.0}]
+        after = [{"text": "Target", "y": 500, "confidence": 1.0}]
+        self.text.side_effect = [before, before, after]
+        result = helpers.scroll_until(
+            lambda boxes: next((b for b in boxes if b["text"] == "Target"), None),
+            amount=0.25, max_scrolls=2, settle=0,
+        )
+        self.assertEqual(result, after[0])
+        self.shell.assert_called_once_with("input swipe 500 1000 500 500 500")
+
+    def test_scroll_collect_deduplicates_and_stops_at_end(self):
+        first = {"text": "First", "y": 500, "confidence": 1.0}
+        second = {"text": "Second", "y": 700, "confidence": 1.0}
+        self.text.side_effect = [[first], [first], [first, second],
+                                 [first, second], [first, second]]
+        result = helpers.scroll_collect(amount=0.25, max_scrolls=3,
+                                        end_after=1, settle=0)
+        self.assertEqual(result, {"items": ["First", "Second"],
+                                  "stop": "reached-end", "scrolls": 2})
+        self.assertEqual(self.shell.call_count, 2)
+        for call in self.shell.call_args_list:
+            self.assertEqual(call.args, ("input swipe 500 1000 500 500 500",))
+
+    def test_transport_scroll_accepts_full_vocabulary_and_optional_dx(self):
+        for deltas, command in (
+            ({"dx": -40, "dy": 30}, "input swipe 100 200 60 230 600"),
+            ({"dy": 30}, "input swipe 100 200 100 230 600"),
+        ):
+            with self.subTest(deltas=deltas):
+                self.shell.reset_mock()
+                self.phone.send("input.scroll", x=100, y=200, steps=12, **deltas)
+                self.shell.assert_called_once_with(command)
 
     def test_raw_vertical_scroll_keeps_existing_positional_arguments(self):
-        phone = Android(serial="test-device")
-        with patch.object(phone, "_gate"), patch.object(phone, "_sh") as shell:
-            phone._input_scroll(100, 200, 30, 2)
-            shell.assert_called_once_with("input swipe 100 200 100 230 150")
+        self.phone._input_scroll(100, 200, 30, 2)
+        self.shell.assert_called_once_with("input swipe 100 200 100 230 150")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What does this PR do?

Every `scroll()` call on Android currently raises `TypeError` before sending a gesture: the helper passes both `dx` and `dy`, but the Android backend only accepts `dy`. Accept `dx` and apply both deltas to the adb swipe endpoint, retaining the old positional `steps` argument and vertical-only raw calls.

## Related Issue

No existing issue for this symptom. This is separate from #56 (the `keystrokes` argument to text input) and the iOS scroll implementation in #52.

## Type of Change

- [x] Bug fix

## Changes Made

- `src/phone_harness/android.py`: accept and apply the horizontal scroll delta.
- `tests/test_android_scroll.py`: cover `scroll()` and `scroll_screen()` in all four directions, changed/unchanged text sets, `scroll_until()` target detection, `scroll_collect()` deduplication/end detection, the full Android scroll argument vocabulary, and legacy vertical-only/positional calls.

## How did you verify it?

| | |
|---|---|
| macOS | 26.5.2 (25F84), Apple silicon |
| Android | Android 16 / API 36, Google APIs arm64 emulator, Pixel 4 AVD profile |
| Transport | adb, emulator-5554 |
| Screen | Android Settings main list |

**Before:** Opened Settings and captured its screenshot and accessibility tree. `scroll("down", amount=0.3)` raised `TypeError: Android._input_scroll() got an unexpected keyword argument 'dx'`; no gesture was sent.

**After:** The same call moved the list upward. In the captured image, Google disappeared above the visible list; Accessibility and Tips & support became visible at the bottom. The post-scroll tree also included the Tips & support description (`Help articles, phone & chat`), absent from the pre-scroll tree. The list had more content below it, so this was not an end-of-list test.

```sh
PYTHONPATH=src python3 -m unittest discover -s tests -v
# before: 4 direction subtests error; after: 2 tests pass
PHONE_HARNESS_TELEMETRY=0 PHONE_HARNESS_PLATFORM=android ANDROID_SERIAL=emulator-5554 ./phone-harness --doctor android
# all clear, exit 0
git diff --check
```

Horizontal command mapping is covered by regression tests; the live screen observation above is a vertical scroll.

Additional regression verification (Windows, Python 3.10.11 and 3.12.10):

- `PYTHONPATH=src python -m unittest discover -s tests -v`: all 6 tests pass on both versions.
- Temporarily substituting the pre-fix Android scroll method produces 15 missing-`dx` errors across the regression cases; the legacy positional call still passes.
- `git diff --check` passes.

These additional checks mock device I/O; they are not new emulator or physical-phone observations. The emulator observations above remain the original implementation validation. The argument guard is scoped to Android `input.scroll`; a backend-wide input contract test would also cover the independent text-input fix in #56.

## Anything you tried that did NOT work

Passing a vertical direction does not avoid the crash: the helper still passes `dx=0`.

## Checklist

- [x] Pulled latest main and reproduced against `6e47f24cd1d6110e9c72dc2bfe559d2ec709e56d`.
- [x] `phone-harness --doctor android` passes in the emulator setup above.
- [x] This PR contains only this fix and its regression tests.
- [x] SKILL.md: N/A; no new agent workflow.
- [x] Backend docstrings reflect the change; helper return shapes are unchanged.

AI-assisted implementation and validation with Codex. No physical phone validation is claimed.
