### PR TITLE
fix(android): keep device connections independent

### DIFF
--- a/src/phone_harness/android.py
+++ b/src/phone_harness/android.py
@@ -21,8 +21,8 @@ step that is missing. Paired phones are
 remembered (see config.py: the devices state file) under a friendly name and
 matched by hardware serial, so a phone whose Wi-Fi port changed overnight is
 still "pixel-8". The first phone paired over Wi-Fi becomes the primary;
-`phone-harness android use NAME` changes that; ANDROID_SERIAL overrides
-everything.
+`phone-harness android use NAME` changes that. An explicit serial argument,
+or ANDROID_SERIAL, overrides automatic discovery for that connection.
 """
 import os
 import re
@@ -136,8 +136,7 @@ class Android(Backend):
     name = "android"
 
     def __init__(self, serial=None):
-        if serial:
-            os.environ["ANDROID_SERIAL"] = serial
+        self._serial = serial or os.environ.get("ANDROID_SERIAL")
         self._bounds = None
         self._resolved = False
         self._gate_at = 0.0
@@ -150,7 +149,7 @@ class Android(Backend):
         unpinned command then fails with "more than one device"."""
         if not self._resolved and self._resolve() is None:
             self._session_require()               # raises with the physical step
-        return _run(*args, binary=binary, timeout=timeout)
+        return _run("-s", self._serial, *args, binary=binary, timeout=timeout)
 
     def _sh(self, cmd, timeout=60):
         return self._adb("shell", cmd, timeout=timeout)
@@ -158,16 +157,17 @@ class Android(Backend):
     # --- choosing the phone -------------------------------------------------
 
     def _resolve(self):
-        """Pin ANDROID_SERIAL to one ready device, connecting a paired phone
+        """Pin this connection to one ready device, connecting a paired phone
         over Wi-Fi if nothing is attached. Returns the adb id or None.
 
-        Order: the user's explicit ANDROID_SERIAL; then a USB phone (wired
-        always wins — it is right there); then a live Wi-Fi link, the saved
+        Order: the explicit serial or ANDROID_SERIAL captured at construction;
+        then a USB phone (wired always wins — it is right there); then a live
+        Wi-Fi link, the saved
         primary first; then mDNS — the primary if it is on the LAN, else the
         first known phone, else any paired phone."""
-        if os.environ.get("ANDROID_SERIAL"):
+        if self._serial:
             self._resolved = True
-            return os.environ["ANDROID_SERIAL"]
+            return self._serial
         cfg = _load()
         primary = (cfg.get("phones") or {}).get(cfg.get("primary") or "", {})
         known = {p.get("serial") for p in (cfg.get("phones") or {}).values()}
@@ -200,7 +200,7 @@ class Android(Backend):
             ready = [r for r in _attached() if r[1] == "device"]
             chosen = pick(ready)
         if chosen is not None:
-            os.environ["ANDROID_SERIAL"] = chosen
+            self._serial = chosen
             self._resolved = True
             try:
                 _remember(cfg, _prop(chosen, "ro.serialno"),
@@ -255,7 +255,7 @@ class Android(Backend):
                 return None
             self._bounds = {"x": 0, "y": 0, "w": int(m.group(1)),
                             "h": int(m.group(2)),
-                            "id": os.environ.get("ANDROID_SERIAL")}
+                            "id": self._serial}
         return self._bounds
 
     def _screen_require(self):

--- a/tests/test_android_device_routing.py
+++ b/tests/test_android_device_routing.py
@@ -1,0 +1,55 @@
+import os
+import unittest
+from unittest.mock import patch
+
+from phone_harness.android import Android
+from phone_harness.transport import connect
+
+
+class AndroidDeviceRoutingTests(unittest.TestCase):
+    def setUp(self):
+        env = patch.dict(os.environ)
+        env.start()
+        self.addCleanup(env.stop)
+        os.environ.pop("ANDROID_SERIAL", None)
+
+    def test_interleaved_connections_route_to_their_own_device(self):
+        with patch("phone_harness.android._run", return_value="ok") as run:
+            first = connect("android", serial="first")
+            first._sh("getprop ro.build.version.sdk")
+            second = connect("android", serial="second")
+            second._sh("getprop ro.build.version.sdk")
+            first._sh("getprop ro.build.version.sdk")
+            self.assertEqual([call.args[:2] for call in run.call_args_list],
+                             [("-s", "first"), ("-s", "second"), ("-s", "first")])
+        self.assertNotIn("ANDROID_SERIAL", os.environ)
+
+    def test_explicit_serial_does_not_change_environment_default(self):
+        os.environ["ANDROID_SERIAL"] = "default"
+        first = Android(serial="explicit")
+        second = Android()
+        self.assertEqual(first._resolve(), "explicit")
+        self.assertEqual(second._resolve(), "default")
+        self.assertEqual(os.environ["ANDROID_SERIAL"], "default")
+
+    def test_bounds_keep_the_connection_identity(self):
+        first = Android(serial="first")
+        second = Android(serial="second")
+        with patch("phone_harness.android._run", return_value="Physical size: 1080x1920"):
+            self.assertEqual(first.send("screen.bounds")["id"], "first")
+            self.assertEqual(second.send("screen.bounds")["id"], "second")
+
+    def test_auto_selection_is_cached_without_changing_process_environment(self):
+        with patch("phone_harness.android._load", return_value={}), \
+             patch("phone_harness.android._attached", return_value=[("usb", "device", "usb")]) as attached, \
+             patch("phone_harness.android._prop", return_value="model"), \
+             patch("phone_harness.android._remember"):
+            phone = Android()
+            self.assertEqual(phone._resolve(), "usb")
+            self.assertEqual(phone._resolve(), "usb")
+            attached.assert_called_once_with()
+        self.assertNotIn("ANDROID_SERIAL", os.environ)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What does this PR do?

Two Android connections currently share `os.environ["ANDROID_SERIAL"]`. Creating the second connection redirects commands and screen IDs from the first connection to the second device, even though `connect()` documents that a script can hold two devices independently. Keep the selected serial on each connection and pass `adb -s` for every device command. Explicit serials no longer overwrite the process-wide default.

## Related Issue

No existing issue for this symptom. This does not change the connect/awake CLI work in #46 or the input-text signature fix in #56.

## Type of Change

- [x] Bug fix

## Changes Made

- `src/phone_harness/android.py`: capture explicit/environment serial per instance, cache automatic selection locally, pin device commands with `-s`, and report that connection's screen ID.
- `tests/test_android_device_routing.py`: interleaved commands, explicit versus environment default, independent bounds, and cached automatic selection without environment mutation.

## How did you verify it?

| | |
|---|---|
| macOS | 26.5.2 (25F84), Apple silicon |
| Android | Two Google APIs arm64 emulators: Android 16 / API 36 and Android 12 / API 31, Pixel 4 AVD profiles |
| Transport | adb, emulator-5554 and emulator-5556 |
| Screen | API 36 Settings and API 31 launcher; routing checked against OS properties and screen IDs |

Created both connections in one Python process:

```python
from phone_harness.transport import connect
a = connect("android", serial="emulator-5554")
b = connect("android", serial="emulator-5556")
print([p.send("raw", cmd="getprop ro.build.version.sdk").strip() for p in (a, b)])
print([p.send("screen.bounds")["id"] for p in (a, b)])
```

**Before:** returned `['31', '31']` and `['emulator-5556', 'emulator-5556']`. Direct `adb -s` checks confirmed the first emulator was API 36, so its connection was demonstrably reading the wrong device.

**After:** the same script returned `['36', '31']` and `['emulator-5554', 'emulator-5556']`. Both devices passed `--doctor android`, including accessible UI trees (136 and 25 nodes).

```sh
PYTHONPATH=src python3 -m unittest discover -s tests -v
# before: 4 failures; after: 4 tests pass
PHONE_HARNESS_TELEMETRY=0 PHONE_HARNESS_PLATFORM=android ANDROID_SERIAL=emulator-5554 ./phone-harness --doctor android
PHONE_HARNESS_TELEMETRY=0 PHONE_HARNESS_PLATFORM=android ANDROID_SERIAL=emulator-5556 ./phone-harness --doctor android
# both all clear, exit 0
git diff --check
```

Wireless pairing/discovery was not exercised on physical hardware; automatic selection is covered with mocked discovery in the regression test.

## Anything you tried that did NOT work

Passing `serial=` to both connections is insufficient on main: the constructor itself writes the shared environment variable.

## Checklist

- [x] Pulled latest main and reproduced against `6e47f24cd1d6110e9c72dc2bfe559d2ec709e56d`.
- [x] `phone-harness --doctor android` passes in the emulator setup above.
- [x] This PR contains only this fix and its regression tests.
- [x] SKILL.md: N/A; no new agent workflow.
- [x] Backend docstrings reflect the change; helper return shapes are unchanged.

AI-assisted implementation and validation with Codex. No physical phone validation is claimed.
