### PR TITLE
fix(android): refresh screen bounds after rotation

### DIFF
--- a/src/phone_harness/android.py
+++ b/src/phone_harness/android.py
@@ -242,20 +242,30 @@ class Android(Backend):
     # --- screen -------------------------------------------------------------
 
     def _screen_bounds(self):
-        if self._bounds is None:
-            if self._resolve() is None:
-                return None
+        """Current default-display pixels, including rotation and size changes."""
+        if self._resolve() is None:
+            return None
+        try:
+            out = self._sh("dumpsys window displays")
+        except RuntimeError:
+            out = ""
+        # wm size describes the unrotated display. WindowManager's current
+        # dimensions match the screenshot and input coordinate space. Read
+        # them each time: one connection can outlive a rotation or wm resize.
+        m = re.search(r"Display: mDisplayId=0\b[^\n]*\n[^\n]*\bcur=(\d+)x(\d+)", out)
+        if not m:
+            # Retain support for devices whose WindowManager dump differs.
             try:
                 out = self._sh("wm size")
             except RuntimeError:
                 return None
             m = (re.search(r"Override size:\s*(\d+)x(\d+)", out)
                  or re.search(r"Physical size:\s*(\d+)x(\d+)", out))
-            if not m:
-                return None
-            self._bounds = {"x": 0, "y": 0, "w": int(m.group(1)),
-                            "h": int(m.group(2)),
-                            "id": os.environ.get("ANDROID_SERIAL")}
+        if not m:
+            return None
+        self._bounds = {"x": 0, "y": 0, "w": int(m.group(1)),
+                        "h": int(m.group(2)),
+                        "id": os.environ.get("ANDROID_SERIAL")}
         return self._bounds
 
     def _screen_require(self):

--- a/tests/test_android_screen_bounds.py
+++ b/tests/test_android_screen_bounds.py
@@ -1,0 +1,65 @@
+import os
+import unittest
+from unittest.mock import patch
+
+from phone_harness.android import Android
+
+
+def display(width, height, display_id=0):
+    return (f"  Display: mDisplayId={display_id} (organized)\n"
+            f"    init=1080x2280 440dpi cur={width}x{height} app={width}x{height}\n")
+
+
+class AndroidScreenBoundsTests(unittest.TestCase):
+    def setUp(self):
+        env = patch.dict(os.environ)
+        env.start()
+        self.addCleanup(env.stop)
+        self.phone = Android(serial="test-device")
+
+    def test_bounds_follow_rotation_and_resize_on_same_connection(self):
+        current = [1080, 2280]
+        def shell(command):
+            if command == "dumpsys window displays":
+                return display(*current)
+            return "Physical size: 1080x2280"
+        with patch.object(self.phone, "_sh", side_effect=shell):
+            for size in [(1080, 2280), (2280, 1080), (720, 1280), (1080, 2280)]:
+                with self.subTest(size=size):
+                    current[:] = size
+                    bounds = self.phone.send("screen.bounds")
+                    self.assertEqual((bounds["w"], bounds["h"]), size)
+                    self.assertEqual(bounds["id"], "test-device")
+
+    def test_secondary_display_is_not_used(self):
+        output = display(800, 600, 2) + display(2280, 1080)
+        with patch.object(self.phone, "_sh", return_value=output):
+            bounds = self.phone.send("screen.bounds")
+        self.assertEqual((bounds["w"], bounds["h"]), (2280, 1080))
+
+    def test_unknown_dump_falls_back_to_override_size(self):
+        def shell(command):
+            return ("unknown format" if command == "dumpsys window displays"
+                    else "Physical size: 1080x2280\nOverride size: 720x1280")
+        with patch.object(self.phone, "_sh", side_effect=shell):
+            bounds = self.phone.send("screen.bounds")
+        self.assertEqual((bounds["w"], bounds["h"]), (720, 1280))
+
+    def test_unavailable_window_dump_falls_back_to_physical_size(self):
+        def shell(command):
+            if command == "dumpsys window displays":
+                raise RuntimeError("not available")
+            return "Physical size: 1080x2280"
+        with patch.object(self.phone, "_sh", side_effect=shell):
+            bounds = self.phone.send("screen.bounds")
+        self.assertEqual((bounds["w"], bounds["h"]), (1080, 2280))
+
+    def test_missing_dimensions_do_not_reuse_stale_bounds(self):
+        with patch.object(self.phone, "_sh", return_value="Physical size: 1080x2280"):
+            self.assertIsNotNone(self.phone.send("screen.bounds"))
+        with patch.object(self.phone, "_sh", return_value="unavailable"):
+            self.assertIsNone(self.phone.send("screen.bounds"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What does this PR do?

Android `screen.bounds` uses `wm size` (the unrotated dimensions) and caches them forever. After a device rotates, `screen.capture` returns a landscape PNG alongside portrait bounds. Helpers that scale screenshot coordinates or calculate gesture positions consequently use the wrong geometry. Read the current default-display dimensions from WindowManager on each bounds request; retain `wm size` as a compatibility fallback when the dump is unavailable or has an unfamiliar format.

## Related Issue

No existing issue for this symptom. This is independent of #62's scroll keyword handling and #63's per-device routing. All three branches are based on main.

## Type of Change

- [x] Bug fix

## Changes Made

- `src/phone_harness/android.py`: use display 0's current dimensions and refresh them instead of reusing stale geometry. The returned bounds shape is unchanged.
- `tests/test_android_screen_bounds.py`: rotation/resize on one connection, multiple display entries, unavailable/unrecognized dumps, override-size fallback and unavailable dimensions after a prior successful read.

## How did you verify it?

| | |
|---|---|
| macOS | 26.5.2 (25F84), Apple silicon |
| Android | Android 12 / API 31 and Android 16 / API 36 Google APIs arm64 emulators, Pixel 4 AVD profiles |
| Transport | adb |
| App / screen | Android Settings, portrait and landscape |

**Before:** On the API 31 emulator, queried bounds on one connection while rotating portrait → landscape → portrait. Compared them with width/height decoded from the actual screencap PNG header:

```text
rotation=0 reported=(1080, 2280) actual_png=(1080, 2280)
rotation=1 reported=(1080, 2280) actual_png=(2280, 1080)
rotation=0 reported=(1080, 2280) actual_png=(1080, 2280)
```

**After:** On both API 31 and API 36, repeated the sequence with `phone.send("screen.capture", path=...)`. The bounds matched the captured PNG on every step:

```text
rotation=0 reported=(1080, 2280) actual_png=(1080, 2280)
rotation=1 reported=(2280, 1080) actual_png=(2280, 1080)
rotation=0 reported=(1080, 2280) actual_png=(1080, 2280)
```

The captured landscape Settings screen was visually inspected as well. Rotation was forced with `adb shell wm fixed-to-user-rotation enabled` and `wm user-rotation lock 0|1` for repeatability; the original rotation mode was restored in `finally`. These were read-only AVD sessions, not physical-phone tests.

```sh
PYTHONPATH=src python3 -m unittest discover -s tests -v
# before: 3 failing assertions and 1 error; after: all 5 tests pass
PHONE_HARNESS_TELEMETRY=0 PHONE_HARNESS_PLATFORM=android ANDROID_SERIAL=emulator-5556 ./phone-harness --doctor android
# all clear, exit 0
git diff --check
```

The compatibility fallback retains the former unrotated `wm size` behavior on unknown WindowManager formats.

## Checklist

- [x] Pulled latest main and reproduced against `6e47f24cd1d6110e9c72dc2bfe559d2ec709e56d`.
- [x] `phone-harness --doctor android` passes on the emulator setup above.
- [x] Only this fix and its regression tests.
- [x] SKILL.md: N/A; no new agent workflow.
- [x] Bounds docstring updated; return shape unchanged.

## Anything you tried that did NOT work

`wm user-rotation lock 1` alone did not rotate the API 36 screen in its initial configuration. Used fixed-to-user-rotation mode and asserted the actual PNG was landscape before treating the run as rotation evidence.

AI-assisted implementation and validation with Codex.
