### PR TITLE
Make the Android path work on Windows (and fix type_text on Android)

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,17 @@ print([o["text"] for o in ocr()][:10])
 PY
 ```
 
+PowerShell has no heredoc; pipe a here-string instead:
+
+```powershell
+@'
+open_app("Notes")
+tap_text("New Note")
+type_text("hello from the harness")
+print([o["text"] for o in ocr()][:10])
+'@ | phone-harness
+```
+
 Helpers are pre-imported. [SKILL.md](SKILL.md) is the agent's day-to-day
 guide; [helpers.py](src/phone_harness/helpers.py) is the full list.
 

--- a/install.md
+++ b/install.md
@@ -1,9 +1,10 @@
 # phone-harness install
 
-phone-harness drives a real phone from a Mac (first-run flow for agents:
+phone-harness drives a real phone from your computer (first-run flow for agents:
 `onboarding.md`; day-to-day usage: `SKILL.md`). It works with an **iPhone** through the macOS
-iPhone Mirroring app, or an **Android** over adb (USB or Wi‑Fi). Same helpers
-either way; you choose a default and can switch per call.
+iPhone Mirroring app (Mac only), or an **Android** over adb (USB or Wi‑Fi, from
+macOS, Windows or Linux). Same helpers either way; you choose a default and can
+switch per call.
 
 ## Common
 
@@ -17,6 +18,23 @@ mkdir -p ~/.claude/skills/phone-harness
 phone-harness skill > ~/.claude/skills/phone-harness/SKILL.md
 mkdir -p "${CODEX_HOME:-$HOME/.codex}/skills/phone-harness"
 phone-harness skill > "${CODEX_HOME:-$HOME/.codex}/skills/phone-harness/SKILL.md"
+```
+
+On Windows, in PowerShell (`${VAR:-default}` is bash syntax — it expands to
+nothing here and the file lands in the wrong place, silently):
+
+```powershell
+git clone https://github.com/ShawnPana/phone-harness $HOME\.phone-harness
+cd $HOME\.phone-harness
+pip install -e .
+
+$claude = "$HOME\.claude\skills\phone-harness"
+New-Item -ItemType Directory -Force -Path $claude | Out-Null
+phone-harness skill | Out-File -Encoding utf8 "$claude\SKILL.md"
+
+$codex = if ($env:CODEX_HOME) { $env:CODEX_HOME } else { "$HOME\.codex" }
+New-Item -ItemType Directory -Force -Path "$codex\skills\phone-harness" | Out-Null
+phone-harness skill | Out-File -Encoding utf8 "$codex\skills\phone-harness\SKILL.md"
 ```
 
 - Python 3.10+. Only the CLI? `pip install phone-harness` works too; the
@@ -51,13 +69,23 @@ the agent's copy matches the code.
 
 ## Android
 
-- `brew install android-platform-tools` (adb). Optional: `brew install scrcpy`
-  for a live mirror window during `phone-harness android awake`.
-- On the phone, once: Settings → About phone → tap **Build number** 7× →
-  Settings → System → **Developer options**.
+- adb: `brew install android-platform-tools` (macOS),
+  `winget install Google.PlatformTools` (Windows),
+  `sudo apt install android-tools-adb` (Linux). Optional, for a live mirror
+  window during `phone-harness android awake`: `brew install scrcpy` /
+  `winget install Genymobile.scrcpy` / `sudo apt install scrcpy`.
+  winget puts both on PATH but only for **newly started** shells — restart the
+  terminal, or skip PATH entirely with
+  `phone-harness config set android.adb C:\path\to\adb.exe` (same for
+  `android.scrcpy`).
+- On the phone, once: Settings → About phone → **Software information** → tap
+  **Build number** 7× → back out to Settings → **Developer options** (on
+  Samsung/One UI it appears at the bottom of the main Settings list). Enabling
+  Developer options is a separate step from **USB debugging** below, and
+  TalkBack's Accessibility → *Developer settings* is an unrelated menu.
 - **USB**: Developer options → **USB debugging** on → plug in → tap **Allow**
   (tick "Always allow from this computer"). Done.
-- **Wi‑Fi** (Android 11+, same network as the Mac): Developer options →
+- **Wi‑Fi** (Android 11+, same network as this computer): Developer options →
   **Wireless debugging** on → tap the row → **Pair device with pairing code** →
   `phone-harness android pair 123456` with the code shown. The phone is
   remembered by name; from then on the harness finds and connects it itself.
@@ -93,7 +121,23 @@ iPhone is driven through the mirroring window, the Android over adb.
   USB debugging?" prompt (replug if it does not appear).
 - **Android — `no-device`**: USB debugging off, cable/port, or for Wi‑Fi:
   Wireless debugging turned itself off (it does after a reboot) or a different
-  network than the Mac. `adb devices` shows what adb sees.
+  network than this computer. `adb devices` shows what adb sees.
+- **Android — `adb devices` is empty over USB on Windows**: the phone can be
+  fully enumerated (it shows up as an MTP drive) and still expose no adb
+  interface, because USB debugging is off — that toggle, not Developer options,
+  is what adds it. Check with
+  `Get-PnpDevice -PresentOnly | ? FriendlyName -match 'ADB'`; if that is empty,
+  turn on USB debugging. If it lists a device with a problem instead, install
+  the OEM driver (Samsung: developer.samsung.com/android-usb-driver).
+- **Android — `adb connect <IP>` says "actively refused"**: `adb connect`
+  defaults to port 5555, which nothing listens on. Android 11+ Wireless
+  debugging uses a random port shown in its dialog — pair first, or pass the
+  full `IP:PORT`. Port 5555 only opens after `adb tcpip 5555`, which itself
+  needs a working USB connection.
+- **Android — pairing finds no phone**: `_adb-tls-pairing` is advertised only
+  while the "Pair device with pairing code" dialog is open on the phone. Keep it
+  open, and if the network blocks mDNS use
+  `phone-harness android pair IP:PORT CODE` with both values from that dialog.
 - **Android — `locked`**: unlock the phone; `phone-harness android awake` keeps
   it awake for the session. The harness never types a PIN.
 - **Android — the tree is unavailable on some screen**: that screen never goes

--- a/src/phone_harness/admin.py
+++ b/src/phone_harness/admin.py
@@ -103,11 +103,14 @@ def _doctor_android():
     adb = str(config.get("android.adb"))
     if not shutil.which(adb):
         _check(f"adb found ({adb})", False,
-               "brew install android-platform-tools, or set android.adb to the binary")
+               f"{config.install_hint('adb')}, or set android.adb to the binary")
         return
     _check(f"adb found ({shutil.which(adb)})", True)
+    scrcpy = str(config.get("android.scrcpy"))
     _check("scrcpy found (optional: live mirror during `android awake`)",
-           bool(shutil.which("scrcpy")), "brew install scrcpy — not required", fatal=False)
+           bool(shutil.which(scrcpy)),
+           f"{config.install_hint('scrcpy')}, or set android.scrcpy to the "
+           "binary — not required", fatal=False)
 
     from . import android
     phone = android.Android()

--- a/src/phone_harness/android.py
+++ b/src/phone_harness/android.py
@@ -43,6 +43,16 @@ from .transport import Backend, Unsupported
 def _adb_bin():
     return str(config.get("android.adb"))
 
+
+def _no_adb(binary):
+    """Why adb could not be run, and the two ways out. Raised instead of
+    letting FileNotFoundError surface as a traceback: a missing binary is a
+    setup step for the user, not a bug."""
+    return RuntimeError(
+        f"adb not found ({binary}). Install Android platform-tools "
+        f"({config.install_hint('adb')}), or point the harness straight at "
+        f"it: phone-harness config set android.adb /path/to/adb")
+
 # input.keys names -> Android keycodes. Modifier chords are not a thing
 # `input keyevent` can express, so combos raise rather than half-work.
 _KEYS = {
@@ -58,7 +68,11 @@ _KEYS = {
 # --- adb, without a device yet -----------------------------------------------
 
 def _run(*args, binary=False, timeout=60, check=True):
-    r = subprocess.run([_adb_bin(), *args], capture_output=True, timeout=timeout)
+    adb = _adb_bin()
+    try:
+        r = subprocess.run([adb, *args], capture_output=True, timeout=timeout)
+    except FileNotFoundError:
+        raise _no_adb(adb) from None
     if check and r.returncode != 0:
         err = (r.stderr or r.stdout).decode(errors="replace").strip()
         raise RuntimeError(f"adb {' '.join(args)} failed: {err}")
@@ -427,10 +441,7 @@ class Android(Backend):
             self._gate_at = 0.0
             self._gate()                       # raises with the unlock message
         if state == "no-adb":
-            raise RuntimeError(
-                "adb isn't available. Install Android platform-tools "
-                "(brew install android-platform-tools) or set "
-                "PHONE_HARNESS_ADB to the adb binary, then retry.")
+            raise _no_adb(_adb_bin())
         if state == "unauthorized":
             raise RuntimeError(
                 "The Android phone is attached but hasn't authorised this "
@@ -444,7 +455,7 @@ class Android(Backend):
         prim = cfg.get("primary")
         known = (f" Your primary phone is '{prim}' — make sure Wireless "
                  "debugging is on and it is on this Wi-Fi; if it forgot this "
-                 "Mac, pair again." if prim else "")
+                 "computer, pair again." if prim else "")
         raise RuntimeError(
             "No Android device is reachable." + known + " To connect one: "
             "USB — Settings > Developer options > USB debugging, plug in, tap "
@@ -570,16 +581,17 @@ def _awake(mirror=True):
     label = _phone_label(adb_id)
     print(f"awake: {label} ({adb_id})", flush=True)
     proc = None
-    if mirror and shutil.which("scrcpy"):
+    scrcpy = shutil.which(str(config.get("android.scrcpy")))
+    if mirror and scrcpy:
         proc = subprocess.Popen(
-            ["scrcpy", "-s", adb_id, "--stay-awake", "--no-audio",
+            [scrcpy, "-s", adb_id, "--stay-awake", "--no-audio",
              "--always-on-top", "--window-title", f"phone-harness: {label}",
              "--window-width", "360"],
             stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
         print("mirror: scrcpy window open (close it to end)", flush=True)
     elif mirror:
-        print("mirror: scrcpy not installed (brew install scrcpy) — keeping "
-              "awake without a window", flush=True)
+        print(f"mirror: scrcpy not installed ({config.install_hint('scrcpy')}) "
+              "— keeping awake without a window", flush=True)
 
     def stop(*_):
         if proc and proc.poll() is None:
@@ -737,7 +749,7 @@ def cli(args):
             if addr is None:
                 print("no phone is offering to pair on this network. Is Wireless "
                       "debugging on, the pairing dialog open, and the phone on the "
-                      "same Wi-Fi as this Mac? If your network blocks mDNS, use: "
+                      "same Wi-Fi as this computer? If your network blocks mDNS, use: "
                       "phone-harness android pair IP:PORT CODE (both shown in the dialog)")
                 return 1
         out = _run("pair", addr, code, timeout=30, check=False)

--- a/src/phone_harness/android.py
+++ b/src/phone_harness/android.py
@@ -337,10 +337,15 @@ class Android(Backend):
             raise Unsupported(f"android has no key named {combo!r}")
         self._sh(f"input keyevent KEYCODE_{code}")
 
-    def _input_text(self, s, delay=0.03):
-        self._gate()
+    def _input_text(self, s, delay=0.03, keystrokes=False):
         """`input text` takes one ASCII token; newlines and backspaces become
-        keyevents, spaces become %s, and the rest is shell-quoted."""
+        keyevents, spaces become %s, and the rest is shell-quoted.
+
+        `keystrokes` exists for parity with iOS, where it picks key events
+        over a paste. adb has only `input text`, which is key events already,
+        so there is nothing here to switch — but the helper always passes the
+        argument, and refusing it made type_text() unusable on Android."""
+        self._gate()
         for i, line in enumerate(s.split("\n")):
             if i:
                 self._sh("input keyevent KEYCODE_ENTER")

--- a/src/phone_harness/config.py
+++ b/src/phone_harness/config.py
@@ -37,6 +37,7 @@ DEFAULTS = {
     "telemetry": True,         # anonymous usage events; `config set telemetry false`
     "android": {
         "adb": "adb",          # the binary; a path if it is not on PATH
+        "scrcpy": "scrcpy",    # the binary; a path if it is not on PATH
         "poke_every": 25,      # seconds between keep-awake pokes
         "mirror": True,        # open scrcpy during `android awake` if installed
     },
@@ -51,6 +52,27 @@ _ENV_ALIASES = {
     "platform": ["PHONE_HARNESS_PLATFORM"],
     "android.adb": ["PHONE_HARNESS_ADB"],
 }
+
+# How you install the external tools, per OS. A hint that names the wrong
+# package manager is worse than no hint — a Windows user has no `brew`.
+_INSTALL_HINTS = {
+    "adb": {
+        "darwin": "brew install android-platform-tools",
+        "win32": "winget install Google.PlatformTools",
+        "linux": "sudo apt install android-tools-adb",
+    },
+    "scrcpy": {
+        "darwin": "brew install scrcpy",
+        "win32": "winget install Genymobile.scrcpy",
+        "linux": "sudo apt install scrcpy",
+    },
+}
+
+
+def install_hint(tool):
+    """The command that installs `tool` on this machine, for error messages."""
+    per_os = _INSTALL_HINTS[tool]
+    return per_os.get(sys.platform, per_os["linux"])
 
 
 # --- where -------------------------------------------------------------------

--- a/src/phone_harness/helpers.py
+++ b/src/phone_harness/helpers.py
@@ -13,7 +13,7 @@ live inside one backend each, behind the ops documented in transport.py, so
 `nav.home` and `screen.text` mean the same thing everywhere even though an
 iPhone answers them with a Cmd+1 keystroke and Vision OCR.
 """
-import hashlib, importlib.util, os, time
+import hashlib, importlib.util, os, struct, time
 from pathlib import Path
 
 from . import transport
@@ -81,11 +81,22 @@ def find_window():
     return send("screen.bounds")
 
 
+def _image_size(path):
+    """Pixel size of a capture. A PNG says so in its header, which costs
+    nothing to read — importing the macOS Vision stack for this would make
+    every caller macOS-only, and Android runs on Windows and Linux too."""
+    with open(path, "rb") as f:
+        head = f.read(24)
+    if head[:8] == b"\x89PNG\r\n\x1a\n" and head[12:16] == b"IHDR":
+        return struct.unpack(">II", head[16:24])
+    from . import ocr as _vision             # anything else: ask the Mac
+    return _vision.image_size(path)
+
+
 def screen_info():
     """{window, frontmost, img_px} — bounds, focus state, capture size."""
-    from . import ocr as _vision
     path, win = send("screen.capture")
-    w, h = _vision.image_size(path)
+    w, h = _image_size(path)
     return {"window": win, "frontmost": bool(send("focus.probe")[0]),
             "img_px": [w, h]}
 

--- a/src/phone_harness/run.py
+++ b/src/phone_harness/run.py
@@ -222,7 +222,9 @@ def _run(args):
         return
     if args or sys.stdin.isatty():
         sys.exit(USAGE)
-    code = sys.stdin.read()
+    # Windows PowerShell writes a UTF-8 BOM when it pipes to a native command,
+    # and Python's exec rejects it as a non-printable character on line 1.
+    code = sys.stdin.read().lstrip("\ufeff")
     if not code.strip():
         sys.exit(USAGE)
     from . import helpers

--- a/src/phone_harness/run.py
+++ b/src/phone_harness/run.py
@@ -178,6 +178,12 @@ def main():
             exit_code=1,
             error_message=str(exc),
         )
+        # RuntimeError is how the harness says "a human has to do something" —
+        # install adb, plug the phone in, tap Allow. That is the answer, not a
+        # crash, so print it plainly. Anything else keeps its traceback.
+        if isinstance(exc, RuntimeError):
+            print(str(exc), file=sys.stderr)
+            sys.exit(1)
         raise
     finally:
         sys.stderr = stderr_tail._wrapped


### PR DESCRIPTION
Setting up an Android on Windows 11 with a Galaxy S10, I could not get through the README's own example. Four of these are Windows-specific; the last one is an Android bug on every OS.

Each commit is standalone and separately revertable.

---

### 1. A missing binary crashed instead of explaining itself

`adb` not on PATH produced a 20-line traceback out of `android awake`, `android pair`, and anything else touching `_run`:

```
  File ".../android.py", line 61, in _run
    r = subprocess.run([_adb_bin(), *args], capture_output=True, timeout=timeout)
FileNotFoundError: [WinError 2] The system cannot find the file specified
```

`--doctor` already handled this and printed a clean `[FAIL]`, so the information existed — it just never reached the normal commands. `_run` now raises the `RuntimeError` the module already uses for "a human has to do something", and `main` prints `RuntimeError` as one stderr line with exit 1. Everything else keeps its traceback.

```
$ phone-harness android awake
adb not found (adb). Install Android platform-tools (winget install
Google.PlatformTools), or point the harness straight at it:
phone-harness config set android.adb /path/to/adb
```

Install hints are now chosen per OS — winget on Windows, apt on Linux, brew on macOS. `brew install scrcpy` is not advice you can act on from PowerShell.

Adds `android.scrcpy` alongside `android.adb`, so the mirror works when scrcpy is installed but not on PATH — the normal state after `winget install`, which only affects newly started shells.

"this Mac" → "this computer" in the pairing and no-device messages.

`install.md` gains PowerShell forms of the setup commands. The bash `${CODEX_HOME:-$HOME/.codex}` expands to *nothing* in PowerShell, so `phone-harness skill > "${CODEX_HOME:-$HOME/.codex}/skills/..."` silently writes the skill file to `<current drive>\skills\...` — no error, wrong place, agent never sees it. Plus Windows entries in "If It Fails" for three dead ends:

- `adb devices` empty while the phone is happily mounted as an MTP drive. USB debugging is a **separate toggle** from Developer options, and without it the phone enumerates with no adb interface at all — visible in Samsung's own INF as `PID_6860 ;MTP` vs `PID_6868 ;Modem+Diagnostic+ADB`. (Nearby trap: TalkBack has an unrelated "Developer settings" under Accessibility, which is what Settings search finds when the real Developer options isn't enabled yet.)
- `adb connect <IP>` refused on 5555 — `adb connect` defaults there, but Android 11+ wireless debugging binds an ephemeral port shown in its dialog, and 5555 only opens after `adb tcpip 5555`, which needs USB working first.
- Pairing finding nothing, because `_adb-tls-pairing` is advertised only while the phone's pairing dialog is open.

### 2. `screen_info()` imported the macOS Vision stack

It is the first example in `phone-harness --help`, and on Windows and Linux it died before reaching the phone:

```
  File ".../helpers.py", line 86, in screen_info
    from . import ocr as _vision
  File ".../ocr.py", line 6, in <module>
    import Quartz
ModuleNotFoundError: No module named 'Quartz'
```

It wanted one thing from that import — the pixel size of the capture — and a PNG states that in its IHDR header. Read it there; keep the macOS path as the fallback for anything that isn't a PNG. Also unbreaks `image_point()` and `tap_image_point()`, which both route through `screen_info()`.

### 3. PowerShell's BOM broke every piped script

PowerShell writes a UTF-8 BOM ahead of anything it pipes to a native command:

```
  File "<string>", line 1
    open_app("Notes")
    ^
SyntaxError: invalid non-printable character U+FEFF
```

Strip a leading BOM before `exec`. The README example is now runnable on Windows; the README also gains the PowerShell here-string form of it, calling `ocr()` — there is no `screen_text()`.

### 4. `type_text()` was unusable on Android — every OS

Not a Windows issue. `helpers.type_text()` always passes `keystrokes=`, and `Android._input_text()` never accepted it:

```
TypeError: Android._input_text() got an unexpected keyword argument 'keystrokes'
```

So `type_text()` raised on Android for everyone. Accepted; on iOS it chooses key events over a paste, and adb's `input text` is key events already, so there is nothing to switch — the signature just has to match its caller. The docstring also moves above `self._gate()`, where it is a docstring rather than a discarded expression.

---

### Testing

Windows 11, Galaxy S10 (SM-G973F), USB. The README example now runs end to end — Samsung Notes opened, `"hello from the harness"` typed into a new note, `ocr()` read it back:

```
'Title'
'hello from the harness'
'Handwriting mode'
```

- `--doctor android` all-clear with adb and scrcpy resolved from config and **neither on PATH**.
- `android awake` opens the scrcpy mirror.
- `android awake`, `android pair`, `--doctor` each print the clean one-liner and exit 1 when adb is missing.

No macOS behaviour changes: hints on darwin are the same brew commands, `android.scrcpy` defaults to `"scrcpy"` (the previous `shutil.which("scrcpy")` lookup), the BOM strip is a no-op without a BOM, and `screen_info()` falls back to the Vision path for non-PNG captures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)